### PR TITLE
Add synchronously entries from resource collections that do no support concurrent access

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/ArchiveEntry.java
+++ b/src/main/java/org/codehaus/plexus/archiver/ArchiveEntry.java
@@ -60,6 +60,8 @@ public class ArchiveEntry
 
     private PlexusIoResourceAttributes attributes;
 
+    private final boolean addSynchronously;
+
     /**
      * @param name     the filename as it will appear in the archive. This is platform-specific
      *                 normalized with File.separatorChar
@@ -92,6 +94,8 @@ public class ArchiveEntry
 
         this.mode = permissions == -1 ? permissions : ( permissions & UnixStat.PERM_MASK ) |
             ( type == FILE ? UnixStat.FILE_FLAG : type == SYMLINK ? UnixStat.LINK_FLAG : UnixStat.DIR_FLAG );
+
+        this.addSynchronously = ( collection != null && !collection.isConcurrentAccessSupported() );
     }
 
     /**
@@ -152,6 +156,17 @@ public class ArchiveEntry
         return ( ( type == FILE ? Archiver.DEFAULT_FILE_MODE
             : type == SYMLINK ? Archiver.DEFAULT_SYMLILNK_MODE : Archiver.DEFAULT_DIR_MODE ) & UnixStat.PERM_MASK ) |
             ( type == FILE ? UnixStat.FILE_FLAG : type == SYMLINK ? UnixStat.LINK_FLAG : UnixStat.DIR_FLAG );
+    }
+
+    /**
+     * Indicates if this entry should be added to the archive synchronously
+     * before adding the next entry and/or accessing the next entry of {@link ResourceIterator}. 
+     * 
+     * @return {@code true} if this entry should be added synchronously
+     */
+    public boolean shouldAddSynchronously()
+    {
+        return addSynchronously;
     }
 
     public static ArchiveEntry createFileEntry( String target, PlexusIoResource resource, int permissions,

--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
@@ -333,7 +333,7 @@ public class JarArchiver
 
         ByteArrayInputStream bais = new ByteArrayInputStream( baos.toByteArray() );
         super.zipFile( createInputStreamSupplier( bais ), zOut, MANIFEST_NAME, System.currentTimeMillis(), null,
-                       DEFAULT_FILE_MODE, null );
+                       DEFAULT_FILE_MODE, null, false );
         super.initZipOutputStream( zOut );
     }
 
@@ -435,7 +435,7 @@ public class JarArchiver
         ByteArrayInputStream bais = new ByteArrayInputStream( baos.toByteArray() );
 
         super.zipFile( createInputStreamSupplier( bais ), zOut, INDEX_NAME, System.currentTimeMillis(), null,
-                       DEFAULT_FILE_MODE, null );
+                       DEFAULT_FILE_MODE, null, true );
     }
 
     /**
@@ -443,7 +443,7 @@ public class JarArchiver
      */
     protected void zipFile( InputStreamSupplier is, ConcurrentJarCreator zOut, String vPath,
                             long lastModified, File fromArchive,
-                            int mode, String symlinkDestination )
+                            int mode, String symlinkDestination, boolean addInParallel )
         throws IOException, ArchiverException
     {
         if ( MANIFEST_NAME.equalsIgnoreCase( vPath ) )
@@ -464,7 +464,7 @@ public class JarArchiver
             {
                 rootEntries.addElement( vPath );
             }
-            super.zipFile( is, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination );
+            super.zipFile( is, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination, addInParallel );
         }
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ArchiveFileComparator.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ArchiveFileComparator.java
@@ -94,6 +94,22 @@ public class ArchiveFileComparator
         is1.close();
         is2.close();
     }
+
+    private static void assertEquals( ArchiveFile file1, TarArchiveEntry entry1,
+                                      ZipFile file2, ZipArchiveEntry entry2 )
+            throws IOException
+    {
+        Assert.assertEquals( entry1.isDirectory(), entry2.isDirectory() );
+
+        final InputStream is1 = file1.getInputStream( entry1 );
+        final InputStream is2 = file2.getInputStream( entry2 );
+        final byte[] bytes1 = IOUtil.toByteArray( is1 );
+        final byte[] bytes2 = IOUtil.toByteArray( is2 );
+        Assert.assertTrue( Arrays.equals( bytes1, bytes2 ) );
+        is1.close();
+        is2.close();
+    }
+
     private static void assertEquals( ZipFile file1, ZipArchiveEntry entry1,
                                       ZipFile file2, ZipArchiveEntry entry2 )
             throws Exception
@@ -131,6 +147,26 @@ public class ArchiveFileComparator
                 Assert.assertNotNull(ze2);
                 assertEquals(file1, ze1, file2, ze2);
 
+            }
+        } );
+        Assert.assertTrue( map2.isEmpty() );
+    }
+
+    
+    public static void assertEquals( final ArchiveFile file1, final ZipFile file2, final String prefix )
+        throws Exception
+    {
+        final Map<String,ZipArchiveEntry> map2 = getFileEntries( file2 );
+        forEachTarArchiveEntry( file1, new TarArchiveEntryConsumer()
+        {
+            public void accept( TarArchiveEntry ze1 )
+                throws IOException
+            {
+                final String name1 = ze1.getName();
+                final String name2 = prefix == null ? name1 : ( prefix + name1 );
+                ZipArchiveEntry ze2 = map2.remove( name2 );
+                Assert.assertNotNull( ze2 );
+                assertEquals( file1, ze1, file2, ze2 );
             }
         } );
         Assert.assertTrue( map2.isEmpty() );

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorTest.java
@@ -75,7 +75,7 @@ public class ConcurrentJarCreatorTest {
                         throw new RuntimeException(e);
                     }
                 }
-            });
+            }, true);
         }
 
     }


### PR DESCRIPTION
This is my attempt to fix #10 

This is somewhat simple approach. It adds entries synchronously while it could add them in parallel as long as it does not add them in parallel with entries from the same resource collection.

Alternative approach could be for example to have `Executor` that allows only one entry from a given non-concurrent collection to be added. Maybe it could lead to better performance but I would rather prefer the simpler approach.