### PR TITLE
Fix potential resource leak in ConcurrentJarCreator

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreator.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreator.java
@@ -121,6 +121,7 @@ public class ConcurrentJarCreator {
         long startAt = System.currentTimeMillis();
         targetStream.close();
         zipCloseElapsed = System.currentTimeMillis() - startAt;
+        metaInfDir.close();
         manifest.close();
         directories.close();
         synchronousEntries.close();


### PR DESCRIPTION
As #15 is now merged, I think now it's good time to fix the potential bug(not closing `metaInfDir`) discussed in the comments.