### PR TITLE
Use PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE for unknown file mode

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -411,7 +411,7 @@ public abstract class AbstractArchiver
     {
         final String destFileName = collection.resources.getName( resource );
 
-        int fromResource = -1;
+        int fromResource = PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE;
         if ( resource instanceof ResourceAttributeSupplier )
         {
             final PlexusIoResourceAttributes attrs = ( (ResourceAttributeSupplier) resource ).getAttributes();

--- a/src/main/java/org/codehaus/plexus/archiver/ArchiveEntry.java
+++ b/src/main/java/org/codehaus/plexus/archiver/ArchiveEntry.java
@@ -86,13 +86,14 @@ public class ArchiveEntry
         this.type = type;
         int permissions = mode;
 
-        if ( mode == -1 && this.attributes == null )
+        if ( mode == PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE && this.attributes == null )
         {
             permissions = resource.isFile() ? Archiver.DEFAULT_FILE_MODE
                 : resource.isSymbolicLink() ? Archiver.DEFAULT_SYMLILNK_MODE : Archiver.DEFAULT_DIR_MODE;
         }
 
-        this.mode = permissions == -1 ? permissions : ( permissions & UnixStat.PERM_MASK ) |
+        this.mode = permissions == PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ? permissions
+            : ( permissions & UnixStat.PERM_MASK ) |
             ( type == FILE ? UnixStat.FILE_FLAG : type == SYMLINK ? UnixStat.LINK_FLAG : UnixStat.DIR_FLAG );
 
         this.addSynchronously = ( collection != null && !collection.isConcurrentAccessSupported() );

--- a/src/main/java/org/codehaus/plexus/archiver/diags/TrackingArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/diags/TrackingArchiver.java
@@ -20,6 +20,7 @@ package org.codehaus.plexus.archiver.diags;
  */
 
 import org.codehaus.plexus.archiver.*;
+import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 import org.codehaus.plexus.components.io.resources.PlexusIoResourceCollection;
 import org.codehaus.plexus.util.StringUtils;
@@ -55,38 +56,39 @@ public class TrackingArchiver
     public void addDirectory( final @Nonnull File directory )
         throws ArchiverException
     {
-        added.add( new Addition( directory, null, null, null, -1 ) );
+        added.add( new Addition( directory, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addDirectory( final @Nonnull File directory, final String prefix )
         throws ArchiverException
     {
-        added.add( new Addition( directory, prefix, null, null, -1 ) );
+        added.add( new Addition( directory, prefix, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addDirectory( final @Nonnull File directory, final String[] includes, final String[] excludes )
         throws ArchiverException
     {
-        added.add( new Addition( directory, null, includes, excludes, -1 ) );
+        added.add( new Addition( directory, null, includes, excludes, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addDirectory( final @Nonnull File directory, final String prefix, final String[] includes,
                               final String[] excludes )
         throws ArchiverException
     {
-        added.add( new Addition( directory, prefix, includes, excludes, -1 ) );
+        added.add( new Addition( directory, prefix, includes, excludes,
+            PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addFileSet( final @Nonnull FileSet fileSet )
         throws ArchiverException
     {
-        added.add( new Addition( fileSet, null, null, null, -1 ) );
+        added.add( new Addition( fileSet, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addFile( final @Nonnull File inputFile, final @Nonnull String destFileName )
         throws ArchiverException
     {
-        added.add( new Addition( inputFile, destFileName, null, null, -1 ) );
+        added.add( new Addition( inputFile, destFileName, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addFile( final @Nonnull File inputFile, final @Nonnull String destFileName, final int permissions )
@@ -98,51 +100,53 @@ public class TrackingArchiver
     public void addArchivedFileSet( final @Nonnull File archiveFile )
         throws ArchiverException
     {
-        added.add( new Addition( archiveFile, null, null, null, -1 ) );
+        added.add( new Addition( archiveFile, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addArchivedFileSet( final @Nonnull File archiveFile, final String prefix )
         throws ArchiverException
     {
-        added.add( new Addition( archiveFile, prefix, null, null, -1 ) );
+        added.add( new Addition( archiveFile, prefix, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addSymlink( String s, String s2 )
         throws ArchiverException
     {
-        added.add( new Addition( s, null, null, null, -1 ) );
+        added.add( new Addition( s, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addSymlink( String s, int i, String s2 )
         throws ArchiverException
     {
-        added.add( new Addition( s, null, null, null, -1 ) );
+        added.add( new Addition( s, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
 
     }
 
     public void addArchivedFileSet( final File archiveFile, final String[] includes, final String[] excludes )
         throws ArchiverException
     {
-        added.add( new Addition( archiveFile, null, includes, excludes, -1 ) );
+        added.add( new Addition( archiveFile, null, includes, excludes,
+            PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addArchivedFileSet( final @Nonnull File archiveFile, final String prefix, final String[] includes,
                                     final String[] excludes )
         throws ArchiverException
     {
-        added.add( new Addition( archiveFile, prefix, includes, excludes, -1 ) );
+        added.add( new Addition( archiveFile, prefix, includes, excludes,
+            PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addArchivedFileSet( final ArchivedFileSet fileSet )
         throws ArchiverException
     {
-        added.add( new Addition( fileSet, null, null, null, -1 ) );
+        added.add( new Addition( fileSet, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addArchivedFileSet( final ArchivedFileSet fileSet, Charset charset )
         throws ArchiverException
     {
-        added.add( new Addition( fileSet, null, null, null, -1 ) );
+        added.add( new Addition( fileSet, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public void addResource( final PlexusIoResource resource, final String destFileName, final int permissions )
@@ -154,7 +158,7 @@ public class TrackingArchiver
     public void addResources( final PlexusIoResourceCollection resources )
         throws ArchiverException
     {
-        added.add( new Addition( resources, null, null, null, -1 ) );
+        added.add( new Addition( resources, null, null, null, PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE ) );
     }
 
     public File getDestFile()

--- a/src/main/java/org/codehaus/plexus/archiver/zip/ZipResource.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ZipResource.java
@@ -45,7 +45,7 @@ public class ZipResource extends AbstractPlexusIoResource
 
     public synchronized PlexusIoResourceAttributes getAttributes()
     {
-        int mode = -1;
+        int mode = PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE;
         if (entry.getPlatform() == ZipArchiveEntry.PLATFORM_UNIX)
         {
             mode = entry.getUnixMode();


### PR DESCRIPTION
Plexus IO 2.7.1 introduces new constant to indicate the absence
of information about a resource octal mode (permissions).

Use it instead of hard-coded `-1`.

Actually `AbstractArchiver` uses quite a lot hard-coded `-1` to indicate absence of explicit file mode, but my understanding is that the others are `AbstractArchiver` related/specific and not the same as `PlexusIoResourceAttributes.UNKNOWN_OCTAL_MODE`. For example `forcedFileMode` set to `-1` means that the entry file mode will not be overridden. 