### PR TITLE
Add fixedEntryModificationTime attribute to AbstractZipArchiver 

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -797,4 +797,22 @@ public class ZipArchiverTest
         }
     }
 
+    public void testFixedEntryModificationTime()
+            throws IOException
+    {
+        final long almostMinDosTime = 315532802000L;
+        final File zipFile = getTestFile( "target/output/zip-with-fixed-entry-modification-times.zip" );
+        final ZipArchiver archiver = getZipArchiver( zipFile );
+        archiver.setFixedEntryModificationTime(almostMinDosTime);
+        archiver.addDirectory(new File( "src/test/resources/zip-timestamp"));
+        archiver.createArchive();
+
+        assertTrue( zipFile.exists() );
+        final ZipFile zf = new ZipFile( zipFile );
+        assertEquals(new Date(almostMinDosTime), zf.getEntry( "file-with-even-time.txt" ).getLastModifiedDate());
+        assertEquals(new Date(almostMinDosTime), zf.getEntry( "file-with-odd-time.txt" ).getLastModifiedDate());
+        assertEquals(new Date(almostMinDosTime), zf.getEntry( "foo/" ).getLastModifiedDate());
+    }
+
 }
+


### PR DESCRIPTION
... to override zipEntry times globally. closes #48
