### PR TITLE
More specific exception for cases when there are no files to archive

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/dir/DirectoryArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/dir/DirectoryArchiver.java
@@ -23,6 +23,7 @@ import org.codehaus.plexus.archiver.AbstractArchiver;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
 import org.codehaus.plexus.archiver.util.ResourceUtils;
 import org.codehaus.plexus.components.io.attributes.SymlinkUtils;
@@ -53,7 +54,7 @@ public class DirectoryArchiver
         final ResourceIterator iter = getResources();
         if ( !iter.hasNext() )
         {
-            throw new ArchiverException( "You must set at least one file." );
+            throw new EmptyArchiveException( "You must set at least one file." );
         }
 
         final File destDirectory = getDestFile();

--- a/src/main/java/org/codehaus/plexus/archiver/exceptions/EmptyArchiveException.java
+++ b/src/main/java/org/codehaus/plexus/archiver/exceptions/EmptyArchiveException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2004 The Apache Software Foundation
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.plexus.archiver.exceptions;
+
+import org.codehaus.plexus.archiver.ArchiverException;
+
+public class EmptyArchiveException
+    extends ArchiverException
+{
+
+    public EmptyArchiveException(String message )
+    {
+        super( message );
+    }
+
+    public EmptyArchiveException(String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+}

--- a/src/main/java/org/codehaus/plexus/archiver/tar/TarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/tar/TarArchiver.java
@@ -30,6 +30,7 @@ import org.codehaus.plexus.archiver.AbstractArchiver;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.util.ResourceUtils;
 import org.codehaus.plexus.archiver.util.Streams;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
@@ -110,7 +111,7 @@ public class TarArchiver
         ResourceIterator iter = getResources();
         if ( !iter.hasNext() )
         {
-            throw new ArchiverException( "You must set at least one file." );
+            throw new EmptyArchiveException( "You must set at least one file." );
         }
 
         File tarFile = getDestFile();

--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
@@ -40,6 +40,7 @@ import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
 import org.codehaus.plexus.archiver.UnixStat;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.util.ResourceUtils;
 import org.codehaus.plexus.components.io.functions.SymlinkDestinationSupplier;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
@@ -254,7 +255,7 @@ public abstract class AbstractZipArchiver
         ResourceIterator iter = getResources();
         if ( !iter.hasNext() && !hasVirtualFiles() )
         {
-            throw new ArchiverException( "You must set at least one file." );
+            throw new EmptyArchiveException( "You must set at least one file." );
         }
 
         zipFile = getDestFile();


### PR DESCRIPTION
This is a pre-requisite for [MASSEMBLY-833](https://issues.apache.org/jira/browse/MASSEMBLY-833). Where it's required to distinguish more cleanly case when archive could not be created, because there were actually no files to archive.

Although it would be possible to use the error message for that purpose, using subclass of _ArchiverException_ allows cleaner exception handling and change of the error message will not effect downstream projects.
