### PR TITLE
Fix setRecompressAddedZips has no effect on the resulting archive

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
@@ -569,7 +569,8 @@ public class JarArchiver
             {
                 zipArchiveOutputStream.setMethod( ZipArchiveOutputStream.STORED );
             }
-            ConcurrentJarCreator ps = new ConcurrentJarCreator( Runtime.getRuntime().availableProcessors() );
+            ConcurrentJarCreator ps =
+                new ConcurrentJarCreator( isRecompressAddedZips(), Runtime.getRuntime().availableProcessors() );
             initZipOutputStream( ps );
             finalizeZipOutputStream( ps );
         }


### PR DESCRIPTION
~~**PLEASE NOTE:** This merge request introduces SNAPSHOT dependency.~~

This merge request update the version of Apache Commons Compress
from 1.11 to 1.13. 1.12 introduces backward incompatible changes - `BZip2CompressorOutputStream` no longer tries to finish the output stream in finalize. This is not a problem because we properly close all `BZip2CompressorOutputStream` and we don't rely on this behavior anyway. Other notable change is that 1.13 requires Java 7 at run-time, but as far I know so does Plexus Archiver.

If you think this fix is ok I could backport it for Plexus Archiver 2.x

Follows the commit message. I think it pretty much describes the changes.

To check if a given entry is zip file or not the first four bit
should be read. There is an issue when entries are being added
asynchronously. Because it's faster to submit entries
than to compress them, input streams are opened faster than
they are closed. Eventually this could lead to too many
open files error.

There was a workaround for this issue. Wrapper around the
`InputStreamSupplier` so the first four bytes are read
when the entry is compressed and not when it's submitted.
That solves the too many open files problem,
but unfortunately has no effect on the resulting archive.
The compression method is determined when the entry is
submitted so changing it afterwards has no effect.

Use the newly introduced `ZipArchiveEntryRequestSupplier`
to supply the whole `ZipArchiveEntryRequest`
(including the compression method) when the entry is
compressed.

Upgrade Apache Commons Compress as the fix relies on
feature introduced in 1.13.

Closes #53 