### PR TITLE
Upgrade the minimum required Java version to 7 and Plexus IO to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,13 +56,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-io</artifactId>
-      <version>2.7.1</version>
-    </dependency>
-    <dependency>
-      <!-- Upgrade to transitive dependency of 'plexus-io' which is JDK 5+ only. -->
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,6 @@
     <url>https://github.com/codehaus-plexus/plexus-archiver/issues</url>
   </issueManagement>
 
-  <properties>
-    <useJvmChmod>true</useJvmChmod>
-  </properties>
-
   <contributors>
     <contributor>
       <name>Dan Tran</name>
@@ -108,11 +104,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <useJvmChmod>${useJvmChmod}</useJvmChmod>
-          </systemPropertyVariables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,8 +166,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -35,7 +35,6 @@ import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
-import org.codehaus.plexus.components.io.attributes.Java7Reflector;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.functions.ResourceAttributeSupplier;
 import org.codehaus.plexus.components.io.resources.AbstractPlexusIoResourceCollection;
@@ -363,7 +362,7 @@ public abstract class AbstractArchiver
 
     private boolean isSymlinkSupported()
     {
-        return Os.isFamily( Os.FAMILY_UNIX ) && Java7Reflector.isAtLeastJava7();
+        return Os.isFamily( Os.FAMILY_UNIX );
     }
 
     @Override

--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -351,7 +351,7 @@ public abstract class AbstractUnArchiver
 
             if ( !isIgnorePermissions() && mode != null && !isDirectory )
             {
-                ArchiveEntryUtils.chmod( f, mode, getLogger(), isUseJvmChmod() );
+                ArchiveEntryUtils.chmod( f, mode );
             }
         }
         catch ( final FileNotFoundException ex )

--- a/src/main/java/org/codehaus/plexus/archiver/Archiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/Archiver.java
@@ -366,20 +366,22 @@ public interface Archiver
     void setDuplicateBehavior( String duplicate );
 
     /**
-     * For java7 and above, new java method will be used, regardless of this setting
      * to use or not the jvm method for file permissions : user all <b>not active for group permissions</b>
      *
      * @since 1.1
      * @param useJvmChmod
+     * @deprecated this setting is now ignored. The jvm is always used.
      */
+    @Deprecated
     void setUseJvmChmod( boolean useJvmChmod );
 
     /**
-     * For java7 and above, new java method will be used, regardless of this setting
      *
      * @since 1.1
      * @return
+     * @deprecated this setting is now ignored. The jvm is always used.
      */
+    @Deprecated
     boolean isUseJvmChmod();
 
     /**

--- a/src/main/java/org/codehaus/plexus/archiver/UnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/UnArchiver.java
@@ -89,13 +89,17 @@ public interface UnArchiver
      *
      * @since 1.1
      * @param useJvmChmod
+     * @deprecated this setting is now ignored. The jvm is always used.
      */
+    @Deprecated
     void setUseJvmChmod( boolean useJvmChmod );
 
     /**
      * @since 1.1
      * @return
+     * @deprecated this setting is now ignored. The jvm is always used.
      */
+    @Deprecated
     boolean isUseJvmChmod();
 
     /**

--- a/src/main/java/org/codehaus/plexus/archiver/bzip2/PlexusIoBzip2ResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/archiver/bzip2/PlexusIoBzip2ResourceCollection.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.WillNotClose;
-import org.codehaus.plexus.components.io.attributes.Java7FileAttributes;
+import org.codehaus.plexus.components.io.attributes.FileAttributes;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.resources.PlexusIoCompressedFileResourceCollection;
 import org.codehaus.plexus.components.io.resources.PlexusIoResourceCollection;
@@ -42,7 +42,7 @@ public class PlexusIoBzip2ResourceCollection
 
     @Override protected PlexusIoResourceAttributes getAttributes( File file ) throws IOException
     {
-        return new Java7FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
+        return new FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
     }
 
     @Override

--- a/src/main/java/org/codehaus/plexus/archiver/dir/DirectoryArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/dir/DirectoryArchiver.java
@@ -190,7 +190,7 @@ public class DirectoryArchiver
     {
         if ( !isIgnorePermissions() )
         {
-            ArchiveEntryUtils.chmod( outFile, entry.getMode(), getLogger(), isUseJvmChmod() );
+            ArchiveEntryUtils.chmod( outFile, entry.getMode() );
         }
 
         outFile.setLastModified( inLastModified == PlexusIoResource.UNKNOWN_MODIFICATION_DATE

--- a/src/main/java/org/codehaus/plexus/archiver/gzip/PlexusIoGzipResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/archiver/gzip/PlexusIoGzipResourceCollection.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nonnull;
 import org.codehaus.plexus.archiver.util.Streams;
-import org.codehaus.plexus.components.io.attributes.Java7FileAttributes;
+import org.codehaus.plexus.components.io.attributes.FileAttributes;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.resources.PlexusIoCompressedFileResourceCollection;
 import org.codehaus.plexus.util.IOUtil;
@@ -49,7 +49,7 @@ public class PlexusIoGzipResourceCollection
     protected PlexusIoResourceAttributes getAttributes( File file )
         throws IOException
     {
-        return new Java7FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
+        return new FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
     }
 
 }

--- a/src/main/java/org/codehaus/plexus/archiver/resources/PlexusIoVirtualFileResource.java
+++ b/src/main/java/org/codehaus/plexus/archiver/resources/PlexusIoVirtualFileResource.java
@@ -20,8 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import javax.annotation.Nonnull;
-import org.codehaus.plexus.components.io.attributes.Java7AttributeUtils;
-import org.codehaus.plexus.components.io.attributes.Java7Reflector;
+import org.codehaus.plexus.components.io.attributes.AttributeUtils;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.functions.ResourceAttributeSupplier;
 import org.codehaus.plexus.components.io.resources.AbstractPlexusIoResource;
@@ -106,14 +105,7 @@ public class PlexusIoVirtualFileResource
     {
         if ( file.exists() )
         {
-            if ( Java7Reflector.isAtLeastJava7() )
-            {
-                return Java7AttributeUtils.getLastModified( getFile() );
-            }
-            else
-            {
-                return getFile().lastModified();
-            }
+            return AttributeUtils.getLastModified( getFile() );
         }
         else
         {

--- a/src/main/java/org/codehaus/plexus/archiver/snappy/PlexusIoSnappyResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/archiver/snappy/PlexusIoSnappyResourceCollection.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import javax.annotation.Nonnull;
 import javax.annotation.WillNotClose;
-import org.codehaus.plexus.components.io.attributes.Java7FileAttributes;
+import org.codehaus.plexus.components.io.attributes.FileAttributes;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.resources.PlexusIoCompressedFileResourceCollection;
 import org.codehaus.plexus.util.IOUtil;
@@ -41,7 +41,7 @@ public class PlexusIoSnappyResourceCollection
 
     @Override protected PlexusIoResourceAttributes getAttributes( File file ) throws IOException
     {
-        return new Java7FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
+        return new FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
     }
 
     @Override

--- a/src/main/java/org/codehaus/plexus/archiver/util/ArchiveEntryUtils.java
+++ b/src/main/java/org/codehaus/plexus/archiver/util/ArchiveEntryUtils.java
@@ -26,36 +26,41 @@ import org.codehaus.plexus.util.Os;
 public final class ArchiveEntryUtils
 {
 
-    public static boolean jvmFilePermAvailable;
-
-    static
-    {
-        try
-        {
-            jvmFilePermAvailable = File.class.getMethod( "setReadable", Boolean.TYPE ) != null;
-        }
-        catch ( final Exception e )
-        {
-            // ignore exception log this ?
-        }
-    }
-
     private ArchiveEntryUtils()
     {
         // no op
     }
 
     /**
-     * @since 1.1
-     * @param file
-     * @param mode
-     * @param logger
-     * @param useJvmChmod
-     * will use jvm file permissions <b>not available for group level</b>
+     * This method is now deprecated.
      *
-     * @throws ArchiverException
+     * The {@code useJvmChmod} flag is ignored as the JVM is always used.
+     * The {@code logger} provided is no longer used.
+     *
+     * @deprecated Use {@link #chmod(File, int)}
      */
+    @Deprecated
     public static void chmod( final File file, final int mode, final Logger logger, boolean useJvmChmod )
+        throws ArchiverException
+    {
+        chmod( file, mode );
+    }
+
+    /**
+     * This method is now deprecated.
+     *
+     * The {@code logger} provided is no longer used.
+     *
+     * @deprecated Use {@link #chmod(File, int)}
+     */
+    @Deprecated
+    public static void chmod( final File file, final int mode, final Logger logger )
+        throws ArchiverException
+    {
+        chmod( file, mode );
+    }
+
+    public static void chmod( final File file, final int mode )
         throws ArchiverException
     {
         if ( !Os.isFamily( Os.FAMILY_UNIX ) )
@@ -71,21 +76,6 @@ public final class ArchiveEntryUtils
         {
             throw new ArchiverException( "Failed setting file attributes", e );
         }
-    }
-
-    /**
-     * <b>jvm chmod will be used only if System property <code>useJvmChmod</code> set to true</b>
-     *
-     * @param file
-     * @param mode
-     * @param logger
-     *
-     * @throws ArchiverException
-     */
-    public static void chmod( final File file, final int mode, final Logger logger )
-        throws ArchiverException
-    {
-        chmod( file, mode, logger, Boolean.getBoolean( "useJvmChmod" ) && jvmFilePermAvailable );
     }
 
 }

--- a/src/main/java/org/codehaus/plexus/archiver/xz/PlexusIoXZResourceCollection.java
+++ b/src/main/java/org/codehaus/plexus/archiver/xz/PlexusIoXZResourceCollection.java
@@ -20,7 +20,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
-import org.codehaus.plexus.components.io.attributes.Java7FileAttributes;
+import org.codehaus.plexus.components.io.attributes.FileAttributes;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.resources.PlexusIoCompressedFileResourceCollection;
 import org.codehaus.plexus.util.IOUtil;
@@ -35,7 +35,7 @@ public class PlexusIoXZResourceCollection extends PlexusIoCompressedFileResource
     @Override
     protected PlexusIoResourceAttributes getAttributes( File file ) throws IOException
     {
-        return new Java7FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
+        return new FileAttributes( file, new HashMap<Integer, String>(), new HashMap<Integer, String>() );
     }
 
     @Override

--- a/src/test/java/org/codehaus/plexus/archiver/jar/DirectoryArchiverUnpackJarTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/jar/DirectoryArchiverUnpackJarTest.java
@@ -11,8 +11,6 @@ import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
 import org.codehaus.plexus.archiver.util.DefaultArchivedFileSet;
 import org.codehaus.plexus.components.io.functions.InputStreamTransformer;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 
 public class DirectoryArchiverUnpackJarTest
     extends PlexusTestCase
@@ -59,14 +57,12 @@ public class DirectoryArchiverUnpackJarTest
         archiver.createArchive();
         assertTrue( new File( "target/depset_unpack/child-1/META-INF/MANIFEST.MF" ).exists() );
 
-        final Logger logger = new ConsoleLogger( Logger.LEVEL_DEBUG, this.getClass().getName() );
-
         // make them writeable or mvn clean will fail
-        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF" ), 0777, logger );
-        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF/maven" ), 0777, logger );
-        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF/maven/test" ), 0777, logger );
-        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF/maven/test/child1" ), 0777, logger );
-        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/assembly-resources" ), 0777, logger );
+        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF" ), 0777 );
+        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF/maven" ), 0777 );
+        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF/maven/test" ), 0777 );
+        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/META-INF/maven/test/child1" ), 0777 );
+        ArchiveEntryUtils.chmod( new File( "target/depset_unpack/child-1/assembly-resources" ), 0777 );
     }
 
 }

--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
@@ -45,8 +45,6 @@ import org.codehaus.plexus.archiver.util.DefaultArchivedFileSet;
 import org.codehaus.plexus.archiver.zip.ArchiveFileComparator;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributeUtils;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.Os;
@@ -60,17 +58,6 @@ import static org.codehaus.plexus.components.io.resources.ResourceFactory.create
 public class TarArchiverTest
     extends PlexusTestCase
 {
-
-    private Logger logger;
-
-    @Override
-    public void setUp()
-        throws Exception
-    {
-        super.setUp();
-
-        logger = new ConsoleLogger( Logger.LEVEL_DEBUG, "test" );
-    }
 
     public void testCreateArchiveWithDetectedModes()
         throws Exception
@@ -275,7 +262,7 @@ public class TarArchiverTest
             IOUtil.close( writer );
         }
 
-        ArchiveEntryUtils.chmod( file, mode, logger, false );
+        ArchiveEntryUtils.chmod( file, mode );
     }
 
     public void testCreateArchive()

--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarFileAttributesTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarFileAttributesTest.java
@@ -9,7 +9,6 @@ import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.util.DefaultArchivedFileSet;
-import org.codehaus.plexus.components.io.attributes.Java7Reflector;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributeUtils;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.util.FileUtils;
@@ -141,10 +140,7 @@ public class TarFileAttributesTest
         PlexusIoResourceAttributes fileAttributes =
             PlexusIoResourceAttributeUtils.getFileAttributes( new File( tempTarDir, tempFile.getName() ) );
 
-        final int expected = Java7Reflector.isAtLeastJava7() ? 0660 : 0644;
-
-        assertEquals( "This test will fail if your umask is not X2X (or more)",
-                      expected, fileAttributes.getOctalMode() );
+        assertEquals( 0660, fileAttributes.getOctalMode() );
 
     }
 
@@ -207,10 +203,7 @@ public class TarFileAttributesTest
 
         fileAttributes = PlexusIoResourceAttributeUtils.getFileAttributes( new File( tempTarDir, tempFile.getName() ) );
 
-        final int expected = Java7Reflector.isAtLeastJava7() ? 0440 : 0444;
-
-        assertEquals( "This test will fail if your umask is not X2X (or more)",
-                      expected, fileAttributes.getOctalMode() );
+        assertEquals( 0440, fileAttributes.getOctalMode() );
 
     }
 
@@ -275,10 +268,7 @@ public class TarFileAttributesTest
         PlexusIoResourceAttributes fileAttributes =
             PlexusIoResourceAttributeUtils.getFileAttributes( new File( tempTarDir, tempFile.getName() ) );
 
-        final int expected = Java7Reflector.isAtLeastJava7() ? 0660 : 0644;
-
-        assertEquals( "This test will fail if your umask is not X2X (or more)",
-                      expected, fileAttributes.getOctalMode() );
+        assertEquals( 0660, fileAttributes.getOctalMode() );
 
     }
 
@@ -345,9 +335,7 @@ public class TarFileAttributesTest
         PlexusIoResourceAttributes fileAttributes =
             PlexusIoResourceAttributeUtils.getFileAttributes( new File( tempTarDir, tempFile.getName() ) );
 
-        final int expected = Java7Reflector.isAtLeastJava7() ? 0660 : 0644;
-        assertEquals( "This test will fail if your umask is not X2X (or more)",
-                      expected, fileAttributes.getOctalMode() );
+        assertEquals( 0660, fileAttributes.getOctalMode() );
 
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/util/ArchiveEntryUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/util/ArchiveEntryUtilsTest.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import org.codehaus.plexus.components.io.attributes.FileAttributes;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.Os;
 import junit.framework.TestCase;
 
@@ -19,8 +18,7 @@ public class ArchiveEntryUtilsTest extends TestCase
             return;
         }
         File temp = File.createTempFile( "A$A", "BB$" );
-        ArchiveEntryUtils.chmod( temp, 0770, new ConsoleLogger( org.codehaus.plexus.logging.Logger.LEVEL_DEBUG, "foo" ),
-                                 false );
+        ArchiveEntryUtils.chmod( temp, 0770 );
         assert0770( temp );
     }
 
@@ -32,8 +30,7 @@ public class ArchiveEntryUtilsTest extends TestCase
         }
 
         File temp = File.createTempFile( "D$D", "BB$" );
-        ArchiveEntryUtils.
-            chmod( temp, 0770, new ConsoleLogger( org.codehaus.plexus.logging.Logger.LEVEL_DEBUG, "foo" ) );
+        ArchiveEntryUtils.chmod( temp, 0770 );
         assert0770( temp );
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/util/ArchiveEntryUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/util/ArchiveEntryUtilsTest.java
@@ -3,8 +3,7 @@ package org.codehaus.plexus.archiver.util;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import org.codehaus.plexus.components.io.attributes.Java7FileAttributes;
-import org.codehaus.plexus.components.io.attributes.Java7Reflector;
+import org.codehaus.plexus.components.io.attributes.FileAttributes;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.Os;
 import junit.framework.TestCase;
@@ -27,10 +26,6 @@ public class ArchiveEntryUtilsTest extends TestCase
 
     public void testChmodWithJava7() throws Exception
     {
-        if ( !Java7Reflector.isAtLeastJava7() )
-        {
-            return; // Require at least java7
-        }
         if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
         {
             return;
@@ -44,8 +39,8 @@ public class ArchiveEntryUtilsTest extends TestCase
 
     private void assert0770( File temp ) throws IOException
     {
-        Java7FileAttributes j7 = new Java7FileAttributes( temp, new HashMap<Integer, String>(),
-                                                          new HashMap<Integer, String>() );
+        FileAttributes j7 = new FileAttributes( temp, new HashMap<Integer, String>(),
+                                                new HashMap<Integer, String>() );
         assertTrue( j7.isGroupExecutable() );
         assertTrue( j7.isGroupReadable() );
         assertTrue( j7.isGroupWritable() );

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -53,7 +53,7 @@ import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
 import org.codehaus.plexus.archiver.util.DefaultArchivedFileSet;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import org.codehaus.plexus.archiver.util.Streams;
-import org.codehaus.plexus.components.io.attributes.Java7FileAttributes;
+import org.codehaus.plexus.components.io.attributes.FileAttributes;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributeUtils;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.components.io.attributes.SimpleResourceAttributes;
@@ -520,7 +520,7 @@ public class ZipArchiverTest
         zipUnArchiver.setDestFile( output );
         zipUnArchiver.extract();
         File symDir = new File( "target/output/unzipped/plexus/src/symDir" );
-        PlexusIoResourceAttributes fa = Java7FileAttributes.uncached( symDir );
+        PlexusIoResourceAttributes fa = FileAttributes.uncached( symDir );
         assertTrue( fa.isSymbolicLink() );
     }
 
@@ -541,7 +541,7 @@ public class ZipArchiverTest
         zipUnArchiver.setDestFile( output );
         zipUnArchiver.extract();
         File symDir = new File( output, "bzz/symDir" );
-        PlexusIoResourceAttributes fa = Java7FileAttributes.uncached( symDir );
+        PlexusIoResourceAttributes fa = FileAttributes.uncached( symDir );
         assertTrue( fa.isSymbolicLink() );
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -61,8 +61,6 @@ import org.codehaus.plexus.components.io.functions.InputStreamTransformer;
 import org.codehaus.plexus.components.io.resources.PlexusIoFileResourceCollection;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 import org.codehaus.plexus.components.io.resources.ResourceFactory;
-import org.codehaus.plexus.logging.Logger;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.Os;
@@ -74,16 +72,6 @@ import org.codehaus.plexus.util.Os;
 public class ZipArchiverTest
     extends BasePlexusArchiverTest
 {
-
-    private Logger logger;
-
-    public void setUp()
-        throws Exception
-    {
-        super.setUp();
-
-        logger = new ConsoleLogger( Logger.LEVEL_DEBUG, "test" );
-    }
 
     public void testImplicitPermissions()
         throws IOException
@@ -342,7 +330,7 @@ public class ZipArchiverTest
             IOUtil.close( writer );
         }
 
-        ArchiveEntryUtils.chmod( file, mode, logger, false );
+        ArchiveEntryUtils.chmod( file, mode );
     }
 
     public void testCreateArchive()


### PR DESCRIPTION
This pull request updates the minimum required Java version to 7 and the  Plexus IO version to 3.0.0

After the update to Java 7 `useJvmChmod` is just ignored. I've added deprecation annotation so it can be removed in future.