### PR TITLE
Throw specific exception when creating empty archive using single file archiver

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/bzip2/BZip2Archiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/bzip2/BZip2Archiver.java
@@ -21,6 +21,7 @@ import org.codehaus.plexus.archiver.AbstractArchiver;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 
 public class BZip2Archiver
     extends AbstractArchiver
@@ -38,6 +39,10 @@ public class BZip2Archiver
         }
 
         ResourceIterator iter = getResources();
+        if ( !iter.hasNext() )
+        {
+            throw new EmptyArchiveException( "You must set at least one file." );
+        }
         ArchiveEntry entry = iter.next();
         if ( iter.hasNext() )
         {

--- a/src/main/java/org/codehaus/plexus/archiver/gzip/GZipArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/gzip/GZipArchiver.java
@@ -21,6 +21,7 @@ import org.codehaus.plexus.archiver.AbstractArchiver;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 
 public class GZipArchiver
     extends AbstractArchiver
@@ -38,6 +39,10 @@ public class GZipArchiver
         }
 
         ResourceIterator iter = getResources();
+        if ( !iter.hasNext() )
+        {
+            throw new EmptyArchiveException( "You must set at least one file." );
+        }
         ArchiveEntry entry = iter.next();
         if ( iter.hasNext() )
         {

--- a/src/main/java/org/codehaus/plexus/archiver/snappy/SnappyArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/snappy/SnappyArchiver.java
@@ -21,6 +21,7 @@ import org.codehaus.plexus.archiver.AbstractArchiver;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 
 /**
  * Snappy archiver.
@@ -41,6 +42,10 @@ public class SnappyArchiver
         }
 
         ResourceIterator iter = getResources();
+        if ( !iter.hasNext() )
+        {
+            throw new EmptyArchiveException( "You must set at least one file." );
+        }
         ArchiveEntry entry = iter.next();
         if ( iter.hasNext() )
         {

--- a/src/main/java/org/codehaus/plexus/archiver/xz/XZArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/xz/XZArchiver.java
@@ -20,6 +20,7 @@ import org.codehaus.plexus.archiver.AbstractArchiver;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.ResourceIterator;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 
 /**
  * @author philiplourandos
@@ -43,6 +44,10 @@ public class XZArchiver extends AbstractArchiver
         }
 
         ResourceIterator iter = getResources();
+        if ( !iter.hasNext() )
+        {
+            throw new EmptyArchiveException( "You must set at least one file." );
+        }
         ArchiveEntry entry = iter.next();
         if ( iter.hasNext() )
         {

--- a/src/test/java/org/codehaus/plexus/archiver/bzip2/BZip2ArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/bzip2/BZip2ArchiverTest.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
@@ -55,6 +56,22 @@ public class BZip2ArchiverTest
         archiver.addDirectory( getTestFile( "target/output" ), inputFiles, null );
         archiver.setDestFile( getTestFile( "target/output/archive.bz2" ) );
         archiver.createArchive();
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        BZip2Archiver archiver = (BZip2Archiver) lookup( Archiver.ROLE, "bzip2" );
+        archiver.setDestFile( getTestFile( "target/output/empty.bz2" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
+        }
     }
 
     public void testCreateResourceCollection()

--- a/src/test/java/org/codehaus/plexus/archiver/gzip/GZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/gzip/GZipArchiverTest.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
@@ -55,6 +56,23 @@ public class GZipArchiverTest
         archiver.addDirectory( getTestFile( "target/output" ), inputFiles, null );
         archiver.setDestFile( getTestFile( "target/output/archive.gzip" ) );
         archiver.createArchive();
+    }
+
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        GZipArchiver archiver = (GZipArchiver) lookup( Archiver.ROLE, "gzip" );
+        archiver.setDestFile( getTestFile( "target/output/empty.gz" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
+        }
     }
 
     public void testCreateResourceCollection()

--- a/src/test/java/org/codehaus/plexus/archiver/snappy/SnappyArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/snappy/SnappyArchiverTest.java
@@ -31,6 +31,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
@@ -55,6 +56,22 @@ public class SnappyArchiverTest
         archiver.addDirectory( getTestFile( "target/output" ), inputFiles, null );
         archiver.setDestFile( getTestFile( "target/output/archive.snappy" ) );
         archiver.createArchive();
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        SnappyArchiver archiver = (SnappyArchiver) lookup( Archiver.ROLE, "snappy" );
+        archiver.setDestFile( getTestFile( "target/output/empty.snappy" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
+        }
     }
 
     public void testCreateResourceCollection()

--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
@@ -38,6 +38,7 @@ import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnixStat;
 import org.codehaus.plexus.archiver.bzip2.BZip2Compressor;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.gzip.GZipCompressor;
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
 import org.codehaus.plexus.archiver.util.Compressor;
@@ -224,6 +225,22 @@ public class TarArchiverTest
                     e.printStackTrace();
                 }
             }
+        }
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        TarArchiver archiver = getPosixTarArchiver();
+        archiver.setDestFile( getTestFile( "target/output/empty.tar" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
         }
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/xz/XzArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/xz/XzArchiverTest.java
@@ -23,6 +23,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
@@ -58,6 +59,22 @@ public class XzArchiverTest extends BasePlexusArchiverTest
         archiver.createArchive();
 
         assertTrue( targetOutputFile.exists() );
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        XZArchiver archiver = (XZArchiver) lookup( Archiver.ROLE, "xz" );
+        archiver.setDestFile( getTestFile( "target/output/empty.xz" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
+        }
     }
 
     public void testCreateResourceCollection() throws Exception

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -48,6 +48,7 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.UnixStat;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarFile;
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
@@ -281,6 +282,22 @@ public class ZipArchiverTest
                     e.printStackTrace();
                 }
             }
+        }
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        ZipArchiver archiver = getZipArchiver();
+        archiver.setDestFile( getTestFile( "target/output/empty.zip" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
         }
     }
 


### PR DESCRIPTION
With the merge of #51 `EmptyArchiveException` is introduced. But it is thrown only by tar and zip (jar/war etc) archives. Archivers that accpet only single file (such as `SnappyArchiver`) throw `NoSuchElementException`.

Closes #52 

p.s. This reminds me that there is a lot of duplicated code. `BZip2Archiver`, `GZipArchiver.java` & co are practically the same, maybe some day we should refactor them to eliminate the code duplication.