### PR TITLE
Fix tests that fail when run twice in a row

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarXzUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarXzUnArchiverTest.java
@@ -20,6 +20,7 @@ import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.xz.XZArchiver;
+import org.codehaus.plexus.util.FileUtils;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 import static org.codehaus.plexus.PlexusTestCase.getTestFile;
@@ -48,6 +49,10 @@ public class TarXzUnArchiverTest extends PlexusTestCase
         assertFalse( file2InTar.exists() );
 
         File testXZFile = getTestFile( "target/output/archive.tar.xz" );
+        if ( testXZFile.exists() )
+        {
+            FileUtils.fileDelete( testXZFile.getPath() );
+        }
         assertFalse( testXZFile.exists() );
 
         tarArchiver.addFile( getTestFile( "src/test/resources/manifests/manifest1.mf" ), fileName1 );

--- a/src/test/java/org/codehaus/plexus/archiver/xz/XzArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/xz/XzArchiverTest.java
@@ -51,6 +51,10 @@ public class XzArchiverTest extends BasePlexusArchiverTest
         inputFiles[0] = "archiveForxz.zip";
 
         File targetOutputFile = getTestFile( "target/output/archive.xz" );
+        if ( targetOutputFile.exists() )
+        {
+            FileUtils.fileDelete( targetOutputFile.getPath() );
+        }
         assertFalse( targetOutputFile.exists() );
 
         archiver.addDirectory( getTestFile( "target/output" ), inputFiles, null );


### PR DESCRIPTION
Some XZ test cases assert if a file created by the execution of the test does not exists. Because they don't try to delete it first, they will fail if run more than once.