### PR TITLE
Test that `EmptyArchiveException` is thrown when creating archives with no files

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
@@ -38,6 +38,7 @@ import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnixStat;
 import org.codehaus.plexus.archiver.bzip2.BZip2Compressor;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.gzip.GZipCompressor;
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
 import org.codehaus.plexus.archiver.util.Compressor;
@@ -224,6 +225,22 @@ public class TarArchiverTest
                     e.printStackTrace();
                 }
             }
+        }
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        TarArchiver archiver = getPosixTarArchiver();
+        archiver.setDestFile( getTestFile( "target/output/empty.tar" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
         }
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -48,6 +48,7 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.UnixStat;
+import org.codehaus.plexus.archiver.exceptions.EmptyArchiveException;
 import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarFile;
 import org.codehaus.plexus.archiver.util.ArchiveEntryUtils;
@@ -281,6 +282,22 @@ public class ZipArchiverTest
                     e.printStackTrace();
                 }
             }
+        }
+    }
+
+    public void testCreateEmptyArchive()
+        throws Exception
+    {
+        ZipArchiver archiver = getZipArchiver();
+        archiver.setDestFile( getTestFile( "target/output/empty.zip" ) );
+        try
+        {
+            archiver.createArchive();
+
+            fail( "Creating empty archive should throw EmptyArchiveException" );
+        }
+        catch ( EmptyArchiveException ignore )
+        {
         }
     }
 


### PR DESCRIPTION
With the merge of #51 `EmptyArchiveException` is introduced.  This commit adds some tests to verify that it is thrown.