### PR TITLE
Add Java 9 to the Travis' build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 
 # No need for preliminary install step.
 install: true


### PR DESCRIPTION
Java 9 is coming soon so it would be nice to have the project built and tested on Java 9 as well.

The change of the distro to `trusty` is required because it's the only one supporting Java 9 right now.