### PR TITLE
Allow archives to be augmented after they are created

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>plexus-archiver</artifactId>
-  <version>3.5.1-SNAPSHOT</version>
+  <version>3.6-SNAPSHOT</version>
   <name>Plexus Archiver Component</name>
 
   <scm>

--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -1007,6 +1007,8 @@ public abstract class AbstractArchiver
         {
             cleanUp();
         }
+
+        postCreateArchive();
     }
 
     protected boolean hasVirtualFiles()
@@ -1032,6 +1034,21 @@ public abstract class AbstractArchiver
     }
 
     protected void validate()
+        throws ArchiverException, IOException
+    {
+    }
+
+    /**
+     * This method is called after the archive creation
+     * completes successfully (no exceptions are thrown).
+     *
+     * Subclasses may override this method in order to
+     * augment or validate the archive after it is
+     * created.
+     *
+     * @since 3.6
+     */
+    protected void postCreateArchive()
         throws ArchiverException, IOException
     {
     }


### PR DESCRIPTION
This method allows subclasses of `AbstractArchiver` to augment archives only after they are successfully created. It is going to be used to update JAR file to modular JAR files.