### PR TITLE
[MASSEMBLY-617] add ability to give a fileSuffix to an AbstractFileSet

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -346,6 +346,7 @@ public abstract class AbstractArchiver
         collection.setCaseSensitive( fileSet.isCaseSensitive() );
         collection.setUsingDefaultExcludes( fileSet.isUsingDefaultExcludes() );
         collection.setStreamTransformer( fileSet.getStreamTransformer() );
+        collection.setFileSuffix( fileSet.getFileSuffix() );
 
         if ( getOverrideDirectoryMode() > -1 || getOverrideFileMode() > -1 )
         {

--- a/src/main/java/org/codehaus/plexus/archiver/BaseFileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/BaseFileSet.java
@@ -64,5 +64,10 @@ public interface BaseFileSet
      * @return The transformers.
      */
     InputStreamTransformer getStreamTransformer();
-
+    
+    /**
+     * Returns the suffix
+     */
+    String getFileSuffix();
+    
 }

--- a/src/main/java/org/codehaus/plexus/archiver/util/AbstractFileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/util/AbstractFileSet.java
@@ -44,6 +44,8 @@ public abstract class AbstractFileSet<T extends AbstractFileSet>
     private boolean includingEmptyDirectories = true;
 
     private InputStreamTransformer streamTransformer = null;
+    
+    private String fileSuffix;
 
     /**
      * Sets a string of patterns, which excluded files
@@ -188,6 +190,17 @@ public abstract class AbstractFileSet<T extends AbstractFileSet>
     public InputStreamTransformer getStreamTransformer()
     {
         return streamTransformer;
+    }
+    
+    public void setFileSuffix(String fileSuffix) 
+    {
+        this.fileSuffix = fileSuffix;
+    }
+        
+    @Override
+    public String getFileSuffix() 
+    {
+        return fileSuffix;
     }
 
 }


### PR DESCRIPTION
Hi

I move the initial PR https://github.com/sonatype/plexus-archiver/pull/25 here.

In order to fix https://issues.apache.org/jira/browse/MASSEMBLY-617, I need to add a capability to AbstractFileSet, to add file suffix.
This PR add this feature, but it need sonatype/plexus-io#7

Tell me if something goes wrong

Thx