### PR TITLE
Fix major Java version detection.

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
@@ -136,15 +136,18 @@ public abstract class AbstractZipArchiver
 
     private static int getJavaVersion()
     {
-        String javaSpecVersion = System.getProperty( "java.specification.version" );
-        if ( javaSpecVersion.contains( "." ) )
-        {//before jdk 9
-            return Integer.parseInt( javaSpecVersion.split( "\\." )[1] );
-        }
-        else
+        return majorJavaVersion( System.getProperty( "java.specification.version" ) );
+    }
+
+    static int majorJavaVersion( final String javaSpecVersion )
+    {
+        final String[] components = javaSpecVersion.split( "\\." );
+        final int version = Integer.parseInt( components[0] );
+        if ( version == 1 )
         {
-            return Integer.parseInt( javaSpecVersion );
+            return Integer.parseInt( components[1]  );
         }
+        return version;
     }
 
     public String getComment()

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -77,6 +77,16 @@ public class ZipArchiverTest
     extends BasePlexusArchiverTest
 {
 
+    public void testMajorJavaVersion()
+    {
+        assertEquals( 6, ZipArchiver.majorJavaVersion( "1.6" ) );
+        assertEquals( 7, ZipArchiver.majorJavaVersion( "1.7" ) );
+        assertEquals( 8, ZipArchiver.majorJavaVersion( "1.8" ) );
+        assertEquals( 9, ZipArchiver.majorJavaVersion( "9" ) );
+        assertEquals( 10, ZipArchiver.majorJavaVersion( "10" ) );
+        assertEquals( 10, ZipArchiver.majorJavaVersion( "10.0.2" ) );
+    }
+
     public void testImplicitPermissions()
         throws IOException
     {


### PR DESCRIPTION
Unfortunately the old version detection code returns 0 for 10.0.2 and then causes problems, see https://github.com/spotify/dockerfile-maven/issues/200 for more information.