### PR TITLE
Make JarArchiver#createManifest protected

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
@@ -319,7 +319,16 @@ public class JarArchiver
                    || super.hasVirtualFiles();
     }
 
-    private Manifest createManifest()
+    /**
+     * Creates the manifest to be added to the JAR archive.
+     * Sub-classes may choose to override this method
+     * in order to inspect or modify the JAR manifest file.
+     *
+     * @return the manifest for the JAR archive.
+     *
+     * @throws ArchiverException
+     */
+    protected Manifest createManifest()
         throws ArchiverException
     {
         Manifest finalManifest = Manifest.getDefaultManifest();


### PR DESCRIPTION
Currently there is no easy way for sub-classes of  `JarArchiver` to update or inspect the manifest file that is going to be added to the archive. Is there any objections to make `JarArchiver#createManifest` protected so sub-classes have access to the manifest?

This change would help with implementing #96. Alternative way is to read the manifest after the jar is created but that would add unnecessary IO.