### PR TITLE
(Reworked) Add ability to limit output size for zip archives (against zip bombs)

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipUnArchiver.java
@@ -29,7 +29,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.codehaus.plexus.archiver.AbstractUnArchiver;
 import org.codehaus.plexus.archiver.ArchiverException;
-import org.codehaus.plexus.components.io.filemappers.FileMapper;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 
 /**
@@ -171,10 +170,10 @@ public abstract class AbstractZipUnArchiver
                 {
                     try ( InputStream in = zf.getInputStream( ze ) )
                     {
-                        extractFileIfIncluded( getSourceFile(), getDestDirectory(), in, fileInfo.getName(),
-                                               new Date( ze.getTime() ), ze.isDirectory(),
-                                               ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
-                                               resolveSymlink( zf, ze ), getFileMappers() );
+                        extractFile( getSourceFile(), getDestDirectory(), in, fileInfo.getName(),
+                                     new Date( ze.getTime() ), ze.isDirectory(),
+                                     ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
+                                     resolveSymlink( zf, ze ), getFileMappers() );
                     }
                 }
             }
@@ -199,14 +198,6 @@ public abstract class AbstractZipUnArchiver
         }
     }
 
-    private void extractFileIfIncluded( final File sourceFile, final File destDirectory, final InputStream inputStream,
-                                        final String name, final Date time, final boolean isDirectory,
-                                        final Integer mode, String symlinkDestination, final FileMapper[] fileMappers )
-        throws IOException, ArchiverException
-    {
-        extractFile( sourceFile, destDirectory, inputStream, name, time, isDirectory, mode, symlinkDestination, fileMappers );
-    }
-
     @Override
     protected void execute( final String path, final File outputDirectory )
         throws ArchiverException
@@ -228,10 +219,10 @@ public abstract class AbstractZipUnArchiver
                 {
                     try ( InputStream in = zipFile.getInputStream( ze ) )
                     {
-                        extractFileIfIncluded( getSourceFile(), outputDirectory, in,
-                                               ze.getName(), new Date( ze.getTime() ), ze.isDirectory(),
-                                               ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
-                                               resolveSymlink( zipFile, ze ), getFileMappers() );
+                        extractFile( getSourceFile(), outputDirectory, in,
+                                     ze.getName(), new Date( ze.getTime() ), ze.isDirectory(),
+                                     ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
+                                     resolveSymlink( zipFile, ze ), getFileMappers() );
                     }
                 }
             }

--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipUnArchiver.java
@@ -29,6 +29,8 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.codehaus.plexus.archiver.AbstractUnArchiver;
 import org.codehaus.plexus.archiver.ArchiverException;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.commons.io.input.CountingInputStream;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 
 /**
@@ -41,6 +43,8 @@ public abstract class AbstractZipUnArchiver
     private static final String NATIVE_ENCODING = "native-encoding";
 
     private String encoding = "UTF8";
+
+    private long maxOutputSize = Long.MAX_VALUE;
 
     public AbstractZipUnArchiver()
     {
@@ -64,6 +68,21 @@ public abstract class AbstractZipUnArchiver
             encoding = null;
         }
         this.encoding = encoding;
+    }
+
+    /**
+     * Set maximum allowed size of the produced output.
+     *
+     * It may be used as a protection against <a href="https://en.wikipedia.org/wiki/Zip_bomb">zip bombs</a>.
+     *
+     * @param maxOutputSize max size of the produced output, in bytes. Must be greater than 0
+     * @throws IllegalArgumentException if specified output size is less or equal to 0
+     */
+    public void setMaxOutputSize( long maxOutputSize ) {
+        if ( maxOutputSize <= 0 ) {
+            throw new IllegalArgumentException( "Invalid max output size specified: " + maxOutputSize );
+        }
+        this.maxOutputSize = maxOutputSize;
     }
 
     private static class ZipEntryFileInfo
@@ -181,6 +200,7 @@ public abstract class AbstractZipUnArchiver
         getLogger().debug( "Expanding: " + getSourceFile() + " into " + outputDirectory );
         try ( ZipFile zipFile = new ZipFile( getSourceFile(), encoding, true ) )
         {
+            long remainingSpace = maxOutputSize;
             final Enumeration<ZipArchiveEntry> e = zipFile.getEntriesInPhysicalOrder();
 
             while ( e.hasMoreElements() )
@@ -196,10 +216,18 @@ public abstract class AbstractZipUnArchiver
                 {
                     try ( InputStream in = zipFile.getInputStream( ze ) )
                     {
-                        extractFile( getSourceFile(), outputDirectory, in,
-                                     ze.getName(), new Date( ze.getTime() ), ze.isDirectory(),
-                                     ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
-                                     resolveSymlink( zipFile, ze ), getFileMappers() );
+                        BoundedInputStream bis = new BoundedInputStream( in, remainingSpace + 1 );
+                        CountingInputStream cis = new CountingInputStream( bis );
+                        extractFile( getSourceFile(), outputDirectory, cis,
+                                ze.getName(), new Date( ze.getTime() ), ze.isDirectory(),
+                                ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
+                                resolveSymlink( zipFile, ze ), getFileMappers() );
+
+                        remainingSpace -= cis.getByteCount();
+                        if ( remainingSpace < 0 )
+                        {
+                            throw new ArchiverException("Maximum output size limit reached");
+                        }
                     }
                 }
             }

--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipUnArchiver.java
@@ -158,31 +158,7 @@ public abstract class AbstractZipUnArchiver
     protected void execute()
         throws ArchiverException
     {
-        getLogger().debug( "Expanding: " + getSourceFile() + " into " + getDestDirectory() );
-        try ( ZipFile zf = new ZipFile( getSourceFile(), encoding, true ) )
-        {
-            final Enumeration<ZipArchiveEntry> e = zf.getEntriesInPhysicalOrder();
-            while ( e.hasMoreElements() )
-            {
-                final ZipArchiveEntry ze = e.nextElement();
-                final ZipEntryFileInfo fileInfo = new ZipEntryFileInfo( zf, ze );
-                if ( isSelected( fileInfo.getName(), fileInfo ) )
-                {
-                    try ( InputStream in = zf.getInputStream( ze ) )
-                    {
-                        extractFile( getSourceFile(), getDestDirectory(), in, fileInfo.getName(),
-                                     new Date( ze.getTime() ), ze.isDirectory(),
-                                     ze.getUnixMode() != 0 ? ze.getUnixMode() : null,
-                                     resolveSymlink( zf, ze ), getFileMappers() );
-                    }
-                }
-            }
-            getLogger().debug( "expand complete" );
-        }
-        catch ( final IOException ioe )
-        {
-            throw new ArchiverException( "Error while expanding " + getSourceFile().getAbsolutePath(), ioe );
-        }
+        execute("", getDestDirectory());
     }
 
     private String resolveSymlink( ZipFile zf, ZipArchiveEntry ze )
@@ -202,6 +178,7 @@ public abstract class AbstractZipUnArchiver
     protected void execute( final String path, final File outputDirectory )
         throws ArchiverException
     {
+        getLogger().debug( "Expanding: " + getSourceFile() + " into " + outputDirectory );
         try ( ZipFile zipFile = new ZipFile( getSourceFile(), encoding, true ) )
         {
             final Enumeration<ZipArchiveEntry> e = zipFile.getEntriesInPhysicalOrder();
@@ -226,6 +203,7 @@ public abstract class AbstractZipUnArchiver
                     }
                 }
             }
+            getLogger().debug( "expand complete" );
         }
         catch ( final IOException ioe )
         {

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipUnArchiverTest.java
@@ -214,6 +214,31 @@ public class ZipUnArchiverTest
         assertTrue( ex.getMessage().startsWith( "Entry is outside of the target directory" ) );
     }
 
+    public void testZipOutputSizeException()
+            throws Exception
+    {
+        Exception ex = null;
+        String s = "target/zip-size-tests";
+        File testZip = new File( getBasedir(), "src/test/jars/test.zip" );
+        File outputDirectory = new File( getBasedir(), s );
+
+        FileUtils.deleteDirectory( outputDirectory );
+
+        try
+        {
+            ZipUnArchiver zu = getZipUnArchiver( testZip );
+            zu.setMaxOutputSize(10L);
+            zu.extract( "", outputDirectory );
+        }
+        catch ( Exception e )
+        {
+            ex = e;
+        }
+
+        assertNotNull( ex );
+        assertTrue( ex.getMessage().startsWith( "Maximum output size limit reached" ) );
+    }
+
     private ZipArchiver getZipArchiver()
     {
         try


### PR DESCRIPTION
Hello,
@satamas asked me to complete the pull-request #115, which had a couple of defects.
Actually, I decided to rewrite the implementation, so this new pull request deserves a separate review and #115 will be dissmissed.

What have been changed:
1) Pull request #115 was rebased onto master after "try-with-resources" #116 commit.
2) I got rid of changes in `AbstractUnArchiver`
3) I got rid of fragile call to `File.size` and replaced it with `CountingInputStream`.
4) Removed duplication of `AbstractZipUnArchiver#execute()` and `AbstractZipUnArchiver#execute(String, File)` by delegating to the latter.

I tried to minimize diff of the files and keep code style. Let me know if something was missed.