### PR TITLE
[MDEP-651] Warn on duplicate archive entries

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -343,9 +343,10 @@ public abstract class AbstractUnArchiver
 
         try
         {
-            if ( f.exists() && ( f.lastModified() >= entryDate.getTime() ) )
+            if ( f.exists() && !StringUtils.equalsIgnoreCase( entryName, canonicalDestPath ) )
             {
-                String message = String.format( "Archive entry %s already exists on disk and is newer", entryName );
+                String message = String.format( "Archive entry %s and existing file %s names differ only by case."
+                        + " This may cause issues on case insensitive file systems.", entryName, canonicalDestPath );
                 getLogger().warn( message );
                 if ( !isOverwrite() ) {
                     return;

--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -343,9 +343,13 @@ public abstract class AbstractUnArchiver
 
         try
         {
-            if ( !isOverwrite() && f.exists() && ( f.lastModified() >= entryDate.getTime() ) )
+            if ( f.exists() && ( f.lastModified() >= entryDate.getTime() ) )
             {
-                return;
+                String message = String.format( "Archive entry %s already exists on disk and is newer", entryName );
+                getLogger().warn( message );
+                if ( !isOverwrite() ) {
+                    return;
+                }
             }
 
             // create intermediary directories - sometimes zip don't add them

--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -345,8 +345,8 @@ public abstract class AbstractUnArchiver
         {
             if ( f.exists() && !StringUtils.equalsIgnoreCase( entryName, canonicalDestPath ) )
             {
-                String message = String.format( "Archive entry %s and existing file %s names differ only by case."
-                        + " This may cause issues on case insensitive file systems.", entryName, canonicalDestPath );
+                String message = String.format( "Archive entry '%s' and existing file '%s' names differ only by case."
+                        + " This may cause issues on case-insensitive filesystems.", entryName, canonicalDestPath );
                 getLogger().warn( message );
                 if ( !isOverwrite() ) {
                     return;

--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -387,6 +387,12 @@ public abstract class AbstractUnArchiver
     // Visible for testing
     protected boolean shouldExtractEntry( File file, String entryName, Date entryDate ) throws IOException
     {
+        //     entryname  | entrydate | filename   | filedate | behavior
+        // (1) readme.txt | 1970      | readme.txt | 2020     | never overwrite
+        // (2) readme.txt | 2020      | readme.txt | 1970     | only overwrite when isOverWrite()
+        // (3) README.txt | 1970      | readme.txt | 2020     | warn + never overwrite
+        // (4) README.txt | 2020      | readme.txt | 1970     | warn + only overwrite when isOverWrite()
+
         String canonicalDestPath = file.getCanonicalPath();
         boolean fileOnDiskIsNewerThanEntry = ( file.lastModified() >= entryDate.getTime() );
         boolean differentCasing = !StringUtils.equalsIgnoreCase( entryName, canonicalDestPath );
@@ -416,6 +422,8 @@ public abstract class AbstractUnArchiver
         {
             getLogger().warn( casingMessage );
         }
+
+        // (2)
         return isOverwrite();
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -18,12 +18,10 @@ package org.codehaus.plexus.archiver;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Date;
 
 import org.codehaus.plexus.components.io.filemappers.FileMapper;
 import org.hamcrest.BaseMatcher;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.core.StringContains;
 import org.junit.After;
@@ -113,29 +111,41 @@ public class AbstractUnArchiverTest
     }
 
     @Test
+    public void shouldExtractWhenFileOnDiskDoesNotExist() throws IOException
+    {
+        // given
+        File file = new File( temporaryFolder.getRoot(), "whatever.txt" ); // does not create the file!
+        String entryname = file.getName();
+        Date entryDate = new Date();
+
+        // when & then
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is ( true ) );
+    }
+
+    @Test
     public void shouldNotExtractWhenFileOnDiskIsNewerThanEntryInArchive() throws IOException
     {
         // given
-        File file = temporaryFolder.newFile( "readme.txt" );
+        File file = temporaryFolder.newFile();
         file.setLastModified( System.currentTimeMillis() );
-        String entryname = "readme.txt";
+        String entryname = file.getName();
         Date entryDate = new Date( 0 );
 
         // when & then
-        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is ( false ) );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is ( false ) );
     }
 
     @Test
     public void shouldNotExtractWhenFileOnDiskIsNewerThanEntryInArchive_andWarnAboutDifferentCasing() throws IOException
     {
         // given
-        File file = temporaryFolder.newFile( "readme.txt" );
+        File file = temporaryFolder.newFile();
         file.setLastModified( System.currentTimeMillis() );
-        String entryname = "README.txt";
+        String entryname = file.getName().toUpperCase();
         Date entryDate = new Date( 0 );
 
         // when & then
-        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is ( false ) );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is ( false ) );
         assertThat( this.log.getWarns(), hasItem( new LogMessageMatcher( "names differ only by case" ) ) );
     }
 
@@ -143,34 +153,34 @@ public class AbstractUnArchiverTest
     public void shouldExtractWhenEntryInArchiveIsNewerThanFileOnDisk() throws IOException
     {
         // given
-        File file = temporaryFolder.newFile( "readme.txt" );
+        File file = temporaryFolder.newFile();
         file.setLastModified( 0 );
-        String entryname = "readme.txt";
+        String entryname = file.getName().toUpperCase();
         Date entryDate = new Date( System.currentTimeMillis() );
 
         // when & then
         this.abstractUnArchiver.setOverwrite( true );
-        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( true ) );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is( true ) );
 
         // when & then
         this.abstractUnArchiver.setOverwrite( false );
-        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( false ) );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is( false ) );
     }
 
     @Test
     public void shouldExtractWhenEntryInArchiveIsNewerThanFileOnDiskAndWarnAboutDifferentCasing() throws IOException
     {
         // given
-        File file = temporaryFolder.newFile( "readme.txt" );
+        File file = temporaryFolder.newFile();
         file.setLastModified( 0 );
-        String entryname = "README.txt";
+        String entryname = file.getName().toUpperCase();
         Date entryDate = new Date( System.currentTimeMillis() );
 
         // when & then
         this.abstractUnArchiver.setOverwrite( true );
-        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( true ) );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is( true ) );
         this.abstractUnArchiver.setOverwrite( false );
-        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( false ) );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is( false ) );
         assertThat( this.log.getWarns(), hasItem( new LogMessageMatcher( "names differ only by case" ) ) );
     }
 

--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -19,13 +19,23 @@ package org.codehaus.plexus.archiver;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Date;
 
 import org.codehaus.plexus.components.io.filemappers.FileMapper;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.core.StringContains;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit test for {@link AbstractUnArchiver}
@@ -37,7 +47,11 @@ public class AbstractUnArchiverTest
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     private AbstractUnArchiver abstractUnArchiver;
+    private CapturingLog log = new CapturingLog( 0 /*debug*/, "AbstractUnArchiver" );
 
     @Before
     public void setUp()
@@ -58,6 +72,7 @@ public class AbstractUnArchiverTest
                 // unused
             }
         };
+        this.abstractUnArchiver.enableLogging( log );
     }
 
     @After
@@ -72,7 +87,7 @@ public class AbstractUnArchiverTest
     {
         // given
         this.thrown.expectMessage( "Entry is outside of the target directory (../PREFIX/ENTRYNAME.SUFFIX)" );
-        final File targetFolder = Files.createTempDirectory( null ).toFile();
+        final File targetFolder = temporaryFolder.newFolder();
         final FileMapper[] fileMappers = new FileMapper[] { new FileMapper()
         {
             @Override
@@ -97,4 +112,93 @@ public class AbstractUnArchiverTest
         // ArchiverException is thrown providing the rewritten path
     }
 
+    @Test
+    public void shouldNotExtractWhenFileOnDiskIsNewerThanEntryInArchive() throws IOException
+    {
+        // given
+        File file = temporaryFolder.newFile( "readme.txt" );
+        file.setLastModified( System.currentTimeMillis() );
+        String entryname = "readme.txt";
+        Date entryDate = new Date( 0 );
+
+        // when & then
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is ( false ) );
+    }
+
+    @Test
+    public void shouldNotExtractWhenFileOnDiskIsNewerThanEntryInArchive_andWarnAboutDifferentCasing() throws IOException
+    {
+        // given
+        File file = temporaryFolder.newFile( "readme.txt" );
+        file.setLastModified( System.currentTimeMillis() );
+        String entryname = "README.txt";
+        Date entryDate = new Date( 0 );
+
+        // when & then
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is ( false ) );
+        assertThat( this.log.getWarns(), hasItem( new LogMessageMatcher( "names differ only by case" ) ) );
+    }
+
+    @Test
+    public void shouldExtractWhenEntryInArchiveIsNewerThanFileOnDisk() throws IOException
+    {
+        // given
+        File file = temporaryFolder.newFile( "readme.txt" );
+        file.setLastModified( 0 );
+        String entryname = "readme.txt";
+        Date entryDate = new Date( System.currentTimeMillis() );
+
+        // when & then
+        this.abstractUnArchiver.setOverwrite( true );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( true ) );
+
+        // when & then
+        this.abstractUnArchiver.setOverwrite( false );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( false ) );
+    }
+
+    @Test
+    public void shouldExtractWhenEntryInArchiveIsNewerThanFileOnDiskAndWarnAboutDifferentCasing() throws IOException
+    {
+        // given
+        File file = temporaryFolder.newFile( "readme.txt" );
+        file.setLastModified( 0 );
+        String entryname = "README.txt";
+        Date entryDate = new Date( System.currentTimeMillis() );
+
+        // when & then
+        this.abstractUnArchiver.setOverwrite( true );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( true ) );
+        this.abstractUnArchiver.setOverwrite( false );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( file, entryname, entryDate ), is( false ) );
+        assertThat( this.log.getWarns(), hasItem( new LogMessageMatcher( "names differ only by case" ) ) );
+    }
+
+    static class LogMessageMatcher extends BaseMatcher<CapturingLog.Message> {
+        private final StringContains delegateMatcher;
+
+        LogMessageMatcher( String needle )
+        {
+            this.delegateMatcher = new StringContains( needle );
+        }
+
+        @Override
+        public void describeTo( Description description )
+        {
+            description.appendText( "a log message with " );
+            delegateMatcher.describeTo( description );
+        }
+
+        @Override
+        public boolean matches( Object item )
+        {
+            if ( item instanceof CapturingLog.Message )
+            {
+                CapturingLog.Message message = (CapturingLog.Message) item;
+                String haystack = message.message;
+                return delegateMatcher.matches( haystack );
+            }
+            return false;
+        }
+    }
 }

--- a/src/test/java/org/codehaus/plexus/archiver/CapturingLog.java
+++ b/src/test/java/org/codehaus/plexus/archiver/CapturingLog.java
@@ -1,0 +1,99 @@
+package org.codehaus.plexus.archiver;
+
+import org.codehaus.plexus.logging.AbstractLogger;
+import org.codehaus.plexus.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CapturingLog extends AbstractLogger
+{
+    public CapturingLog( int threshold, String name )
+    {
+        super( threshold, name );
+    }
+
+    static class Message {
+        public final String message;
+        public final Throwable throwable;
+
+        public Message( String message, Throwable throwable )
+        {
+            this.message = message;
+            this.throwable = throwable;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Message{" + "message='" + message + '\'' + ", throwable=" + throwable + '}';
+        }
+    }
+
+    private final List<Message> debugs = new ArrayList<>();
+    @Override
+    public void debug( String s, Throwable throwable )
+    {
+        debugs.add( new Message( s, throwable ) );
+    }
+
+    public List<Message> getDebugs()
+    {
+        return debugs;
+    }
+
+
+    private final List<Message> infos = new ArrayList<>();
+    @Override
+    public void info( String s, Throwable throwable )
+    {
+        infos.add( new Message( s, throwable ) );
+    }
+
+    public List<Message> getInfos()
+    {
+        return infos;
+    }
+
+    private final List<Message> warns = new ArrayList<>();
+    @Override
+    public void warn( String s, Throwable throwable )
+    {
+        warns.add( new Message( s, throwable ) );
+    }
+
+    public List<Message> getWarns()
+    {
+        return warns;
+    }
+
+    private final List<Message> errors = new ArrayList<>();
+    @Override
+    public void error( String s, Throwable throwable )
+    {
+        errors.add( new Message( s, throwable ) );
+    }
+
+    public List<Message> getErors()
+    {
+        return errors;
+    }
+
+    private final List<Message> fatals = new ArrayList<>();
+    @Override
+    public void fatalError( String s, Throwable throwable )
+    {
+        fatals.add( new Message( s, throwable ) );
+    }
+
+    public List<Message> getFatals()
+    {
+        return fatals;
+    }
+
+    @Override
+    public Logger getChildLogger( String s )
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
If there's an file system entry for the archive entry currently being extracted, a warning is
logged. If overwrite is false, extraction is aborted.

@rfscholte checked with @viqueen, as this PR superseedes #112, but it's less strict - this one will not fail the build.