### PR TITLE
Replace java.util.jar Manifest classes with ones based on Apache Harmony

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
@@ -445,7 +445,7 @@ public class JarArchiver
 
         if ( indexJars != null )
         {
-            java.util.jar.Manifest mf = createManifest();
+            org.codehaus.plexus.archiver.jar.harmony.Manifest mf = createManifest();
             String classpath = mf.getMainAttributes().getValue( ManifestConstants.ATTRIBUTE_CLASSPATH );
             String[] cpEntries = null;
             if ( classpath != null )

--- a/src/main/java/org/codehaus/plexus/archiver/jar/JdkManifestFactory.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JdkManifestFactory.java
@@ -19,7 +19,7 @@ package org.codehaus.plexus.archiver.jar;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
-import java.util.jar.Attributes;
+import org.codehaus.plexus.archiver.jar.harmony.Attributes;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.util.PropertyUtils;
 
@@ -31,10 +31,10 @@ import org.codehaus.plexus.util.PropertyUtils;
 class JdkManifestFactory
 {
 
-    public static java.util.jar.Manifest getDefaultManifest()
+    public static org.codehaus.plexus.archiver.jar.harmony.Manifest getDefaultManifest()
         throws ArchiverException
     {
-        final java.util.jar.Manifest defaultManifest = new java.util.jar.Manifest();
+        final org.codehaus.plexus.archiver.jar.harmony.Manifest defaultManifest = new org.codehaus.plexus.archiver.jar.harmony.Manifest();
         defaultManifest.getMainAttributes().putValue( "Manifest-Version", "1.0" );
 
         String createdBy = "Plexus Archiver";
@@ -68,7 +68,7 @@ class JdkManifestFactory
         }
     }
 
-    public static void merge( java.util.jar.Manifest target, java.util.jar.Manifest other, boolean overwriteMain )
+    public static void merge( org.codehaus.plexus.archiver.jar.harmony.Manifest target, org.codehaus.plexus.archiver.jar.harmony.Manifest other, boolean overwriteMain )
     {
         if ( other != null )
         {
@@ -108,11 +108,11 @@ class JdkManifestFactory
      * @param target The target manifest of the merge
      * @param section the section to be merged with this one.
      */
-    public static void mergeAttributes( java.util.jar.Attributes target, java.util.jar.Attributes section )
+    public static void mergeAttributes( org.codehaus.plexus.archiver.jar.harmony.Attributes target, org.codehaus.plexus.archiver.jar.harmony.Attributes section )
     {
         for ( Object o : section.keySet() )
         {
-            java.util.jar.Attributes.Name key = (Attributes.Name) o;
+            org.codehaus.plexus.archiver.jar.harmony.Attributes.Name key = (Attributes.Name) o;
             final Object value = section.get( o );
             // the merge file always wins
             target.put( key, value );

--- a/src/main/java/org/codehaus/plexus/archiver/jar/Manifest.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/Manifest.java
@@ -31,8 +31,8 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.StringTokenizer;
 import java.util.Vector;
-import java.util.jar.Attributes;
 import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.jar.harmony.Attributes;
 
 /**
  * Holds the data of a jar manifest.
@@ -50,7 +50,7 @@ import org.codehaus.plexus.archiver.ArchiverException;
  * @since Ant 1.4
  */
 public class Manifest
-    extends java.util.jar.Manifest implements Iterable<String>
+    extends org.codehaus.plexus.archiver.jar.harmony.Manifest implements Iterable<String>
 {
 
     /**

--- a/src/main/java/org/codehaus/plexus/archiver/jar/harmony/Attributes.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/harmony/Attributes.java
@@ -1,0 +1,513 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.plexus.archiver.jar.harmony;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The {@code Attributes} class is used to store values for manifest entries.
+ * Attribute keys are generally instances of {@code Attributes.Name}. Values
+ * associated with attribute keys are of type {@code String}.
+ */
+public class Attributes implements Cloneable, Map<Object, Object> {
+
+    /**
+     * The {@code Attributes} as name/value pairs. Maps the attribute names (as
+     * {@link Attributes.Name}) of a JAR file manifest to arbitrary values. The
+     * attribute names thus are obtained from the {@link Manifest} for
+     * convenience.
+     */
+    protected Map<Object, Object> map;
+
+    /**
+     * The name part of the name/value pairs constituting an attribute as
+     * defined by the specification of the JAR manifest. May be composed of the
+     * following ASCII signs as defined in the EBNF below:
+     *
+     * <pre>
+     * name       = alphanum *headerchar
+     * headerchar = alphanum | - | _
+     * alphanum   = {A-Z} | {a-z} | {0-9}
+     * </pre>
+     */
+    public static class Name {
+        private final byte[] name;
+
+        private int hashCode;
+
+        /**
+         * The class path (a main attribute).
+         */
+        public static final Name CLASS_PATH = new Name("Class-Path"); //$NON-NLS-1$
+
+        /**
+         * The version of the manifest file (a main attribute).
+         */
+        public static final Name MANIFEST_VERSION = new Name("Manifest-Version"); //$NON-NLS-1$
+
+        /**
+         * The main class's name (for stand-alone applications).
+         */
+        public static final Name MAIN_CLASS = new Name("Main-Class"); //$NON-NLS-1$
+
+        /**
+         * Defines the signature version of the JAR file.
+         */
+        public static final Name SIGNATURE_VERSION = new Name(
+                "Signature-Version"); //$NON-NLS-1$
+
+        /**
+         * The {@code Content-Type} manifest attribute.
+         */
+        public static final Name CONTENT_TYPE = new Name("Content-Type"); //$NON-NLS-1$
+
+        /**
+         * The {@code Sealed} manifest attribute which may have the value
+         * {@code true} for sealed archives.
+         */
+        public static final Name SEALED = new Name("Sealed"); //$NON-NLS-1$
+
+        /**
+         * The {@code Implementation-Title} attribute whose value is a string
+         * that defines the title of the extension implementation.
+         */
+        public static final Name IMPLEMENTATION_TITLE = new Name(
+                "Implementation-Title"); //$NON-NLS-1$
+
+        /**
+         * The {@code Implementation-Version} attribute defining the version of
+         * the extension implementation.
+         */
+        public static final Name IMPLEMENTATION_VERSION = new Name(
+                "Implementation-Version"); //$NON-NLS-1$
+
+        /**
+         * The {@code Implementation-Vendor} attribute defining the organization
+         * that maintains the extension implementation.
+         */
+        public static final Name IMPLEMENTATION_VENDOR = new Name(
+                "Implementation-Vendor"); //$NON-NLS-1$
+
+        /**
+         * The {@code Specification-Title} attribute defining the title of the
+         * extension specification.
+         */
+        public static final Name SPECIFICATION_TITLE = new Name(
+                "Specification-Title"); //$NON-NLS-1$
+
+        /**
+         * The {@code Specification-Version} attribute defining the version of
+         * the extension specification.
+         */
+        public static final Name SPECIFICATION_VERSION = new Name(
+                "Specification-Version"); //$NON-NLS-1$
+
+        /**
+         * The {@code Specification-Vendor} attribute defining the organization
+         * that maintains the extension specification.
+         */
+        public static final Name SPECIFICATION_VENDOR = new Name(
+                "Specification-Vendor"); //$NON-NLS-1$
+
+        /**
+         * The {@code Extension-List} attribute defining the extensions that are
+         * needed by the applet.
+         */
+        public static final Name EXTENSION_LIST = new Name("Extension-List"); //$NON-NLS-1$
+
+        /**
+         * The {@code Extension-Name} attribute which defines the unique name of
+         * the extension.
+         */
+        public static final Name EXTENSION_NAME = new Name("Extension-Name"); //$NON-NLS-1$
+
+        /**
+         * The {@code Extension-Installation} attribute.
+         */
+        public static final Name EXTENSION_INSTALLATION = new Name(
+                "Extension-Installation"); //$NON-NLS-1$
+
+        /**
+         * The {@code Implementation-Vendor-Id} attribute specifies the vendor
+         * of an extension implementation if the applet requires an
+         * implementation from a specific vendor.
+         */
+        public static final Name IMPLEMENTATION_VENDOR_ID = new Name(
+                "Implementation-Vendor-Id"); //$NON-NLS-1$
+
+        /**
+         * The {@code Implementation-URL} attribute specifying a URL that can be
+         * used to obtain the most recent version of the extension if the
+         * required version is not already installed.
+         */
+        public static final Name IMPLEMENTATION_URL = new Name(
+                "Implementation-URL"); //$NON-NLS-1$
+
+        static final Name NAME = new Name("Name"); //$NON-NLS-1$
+
+        /**
+         * A String which must satisfy the following EBNF grammar to specify an
+         * additional attribute:
+         *
+         * <pre>
+         * name       = alphanum *headerchar
+         * headerchar = alphanum | - | _
+         * alphanum   = {A-Z} | {a-z} | {0-9}
+         * </pre>
+         *
+         * @param s
+         *            The Attribute string.
+         * @exception IllegalArgumentException
+         *                if the string does not satisfy the EBNF grammar.
+         */
+        public Name(String s) {
+            int i = s.length();
+            if (i == 0 || i > Manifest.LINE_LENGTH_LIMIT - 2) {
+                throw new IllegalArgumentException();
+            }
+
+            name = new byte[i];
+
+            for (; --i >= 0;) {
+                char ch = s.charAt(i);
+                if (!((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+                        || ch == '_' || ch == '-' || (ch >= '0' && ch <= '9'))) {
+                    throw new IllegalArgumentException(s);
+                }
+                name[i] = (byte) ch;
+            }
+        }
+
+        /**
+         * A private constructor for a trusted attribute name.
+         */
+        Name(byte[] buf) {
+            name = buf;
+        }
+
+        byte[] getBytes() {
+            return name;
+        }
+
+        /**
+         * Returns this attribute name.
+         *
+         * @return the attribute name.
+         */
+        @Override
+        public String toString() {
+            try {
+                return new String(name, "ISO-8859-1"); //$NON-NLS-1$
+            } catch (UnsupportedEncodingException iee) {
+                throw new InternalError(iee.getLocalizedMessage());
+            }
+        }
+
+        /**
+         * Returns whether the argument provided is the same as the attribute
+         * name.
+         *
+         * @return if the attribute names correspond.
+         * @param object
+         *            An attribute name to be compared with this name.
+         */
+        @Override
+        public boolean equals(Object object) {
+            if (object == null || object.getClass() != getClass()
+                    || object.hashCode() != hashCode()) {
+                return false;
+            }
+
+            return Util.asciiEqualsIgnoreCase(name, ((Name) object).name);
+        }
+
+        /**
+         * Computes a hash code of the name.
+         *
+         * @return the hash value computed from the name.
+         */
+        @Override
+        public int hashCode() {
+            if (hashCode == 0) {
+                int hash = 0, multiplier = 1;
+                for (int i = name.length - 1; i >= 0; i--) {
+                    // 'A' & 0xDF == 'a' & 0xDF, ..., 'Z' & 0xDF == 'z' & 0xDF
+                    hash += (name[i] & 0xDF) * multiplier;
+                    int shifted = multiplier << 5;
+                    multiplier = shifted - multiplier;
+                }
+                hashCode = hash;
+            }
+            return hashCode;
+        }
+
+    }
+
+    /**
+     * Constructs an {@code Attributes} instance.
+     */
+    public Attributes() {
+        map = new LinkedHashMap<Object, Object>();
+    }
+
+    /**
+     * Constructs an {@code Attributes} instance obtaining keys and values from
+     * the parameter {@code attrib}.
+     *
+     * @param attrib
+     *            The attributes to obtain entries from.
+     */
+    @SuppressWarnings("unchecked")
+    public Attributes(Attributes attrib) {
+        map = (Map<Object, Object>) ((LinkedHashMap) attrib.map).clone();
+    }
+
+    /**
+     * Constructs an {@code Attributes} instance with initial capacity of size
+     * {@code size}.
+     *
+     * @param size
+     *            Initial size of this {@code Attributes} instance.
+     */
+    public Attributes(int size) {
+        map = new LinkedHashMap<Object, Object>(size);
+    }
+
+    /**
+     * Removes all key/value pairs from this {@code Attributes}.
+     */
+    public void clear() {
+        map.clear();
+    }
+
+    /**
+     * Determines whether this {@code Attributes} contains the specified key.
+     *
+     * @param key
+     *            The key to search for.
+     * @return {@code true} if the key is found, {@code false} otherwise.
+     */
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    /**
+     * Determines whether this {@code Attributes} contains the specified value.
+     *
+     * @param value
+     *            the value to search for.
+     * @return {@code true} if the value is found, {@code false} otherwise.
+     */
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    /**
+     * Returns a set containing map entries for each of the key/value pair
+     * contained in this {@code Attributes}.
+     *
+     * @return a set of Map.Entry's
+     */
+    public Set<Map.Entry<Object, Object>> entrySet() {
+        return map.entrySet();
+    }
+
+    /**
+     * Returns the value associated with the parameter key.
+     *
+     * @param key
+     *            the key to search for.
+     * @return Object associated with key, or {@code null} if key does not
+     *         exist.
+     */
+    public Object get(Object key) {
+        return map.get(key);
+    }
+
+    /**
+     * Determines whether this {@code Attributes} contains any keys.
+     *
+     * @return {@code true} if one or more keys exist, {@code false} otherwise.
+     */
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    /**
+     * Returns a {@code Set} containing all the keys found in this {@code
+     * Attributes}.
+     *
+     * @return a {@code Set} of all keys.
+     */
+    public Set<Object> keySet() {
+        return map.keySet();
+    }
+
+    /**
+     * Stores key/value pairs in this {@code Attributes}.
+     *
+     * @param key
+     *            the key to associate with value.
+     * @param value
+     *            the value to store in this {@code Attributes}.
+     * @return the value being stored.
+     * @exception ClassCastException
+     *                when key is not an {@code Attributes.Name} or value is not
+     *                a {@code String}.
+     */
+    @SuppressWarnings("cast")
+    // Require cast to force ClassCastException
+    public Object put(Object key, Object value) {
+        return map.put((Name) key, (String) value);
+    }
+
+    /**
+     * Stores all the key/value pairs in the argument in this {@code
+     * Attributes}.
+     *
+     * @param attrib
+     *            the associations to store (must be of type {@code
+     *            Attributes}).
+     */
+    public void putAll(Map<?, ?> attrib) {
+        if (attrib == null || !(attrib instanceof Attributes)) {
+            throw new ClassCastException();
+        }
+        this.map.putAll(attrib);
+    }
+
+    /**
+     * Deletes the key/value pair with key {@code key} from this {@code
+     * Attributes}.
+     *
+     * @param key
+     *            the key to remove.
+     * @return the values associated with the removed key, {@code null} if not
+     *         present.
+     */
+    public Object remove(Object key) {
+        return map.remove(key);
+    }
+
+    /**
+     * Returns the number of key/value pairs associated with this {@code
+     * Attributes}.
+     *
+     * @return the size of this {@code Attributes}.
+     */
+    public int size() {
+        return map.size();
+    }
+
+    /**
+     * Returns a collection of all the values present in this {@code
+     * Attributes}.
+     *
+     * @return a collection of all values present.
+     */
+    public Collection<Object> values() {
+        return map.values();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object clone() {
+        Attributes clone;
+        try {
+            clone = (Attributes) super.clone();
+        } catch (CloneNotSupportedException e) {
+            return null;
+        }
+        clone.map = (Map<Object, Object>) ((LinkedHashMap) map).clone();
+        return clone;
+    }
+
+    /**
+     * Returns the hash code of this {@code Attributes}.
+     *
+     * @return the hash code of this object.
+     */
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+
+    /**
+     * Determines if this {@code Attributes} and the parameter {@code
+     * Attributes} are equal. Two {@code Attributes} instances are equal if they
+     * contain the same keys and values.
+     *
+     * @param obj
+     *            the object with which this {@code Attributes} is compared.
+     * @return {@code true} if the {@code Attributes} are equal, {@code false}
+     *         otherwise.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof Attributes) {
+            return map.equals(((Attributes) obj).map);
+        }
+        return false;
+    }
+
+    /**
+     * Returns the value associated with the parameter {@code Attributes.Name}
+     * key.
+     *
+     * @param name
+     *            the key to obtain the value for.
+     * @return the {@code String} associated with name, or {@code null} if name
+     *         is not a valid key.
+     */
+    public String getValue(Attributes.Name name) {
+        return (String) map.get(name);
+    }
+
+    /**
+     * Returns the string associated with the parameter name.
+     *
+     * @param name
+     *            the key to obtain the value for.
+     * @return the string associated with name, or {@code null} if name is not a
+     *         valid key.
+     */
+    public String getValue(String name) {
+        return (String) map.get(new Attributes.Name(name));
+    }
+
+    /**
+     * Stores the value {@code val} associated with the key {@code name} in this
+     * {@code Attributes}.
+     *
+     * @param name
+     *            the key to store.
+     * @param val
+     *            the value to store in this {@code Attributes}.
+     * @return the value being stored.
+     */
+    public String putValue(String name, String val) {
+        return (String) map.put(new Attributes.Name(name), val);
+    }
+}

--- a/src/main/java/org/codehaus/plexus/archiver/jar/harmony/InitManifest.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/harmony/InitManifest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.plexus.archiver.jar.harmony;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.util.Arrays;
+import java.util.Map;
+
+class InitManifest {
+
+    private byte[] buf;
+
+    private int pos;
+
+    Attributes.Name name;
+
+    String value;
+
+    CharsetDecoder decoder = ThreadLocalCache.utf8Decoder.get();
+    CharBuffer cBuf = ThreadLocalCache.charBuffer.get();
+
+    InitManifest(byte[] buf, Attributes main, Attributes.Name ver)
+            throws IOException {
+
+        this.buf = buf;
+
+        // check a version attribute
+        if (!readHeader() || (ver != null && !name.equals(ver))) {
+            throw new IOException(
+                    "Missing version attribute: " + ver); //$NON-NLS-1$
+        }
+
+        main.put(name, value);
+        while (readHeader()) {
+            main.put(name, value);
+        }
+    }
+
+    void initEntries(Map<String, Attributes> entries,
+            Map<String, Manifest.Chunk> chunks) throws IOException {
+
+        int mark = pos;
+        while (readHeader()) {
+            if (!Attributes.Name.NAME.equals(name)) {
+                throw new IOException("Entry is not named"); //$NON-NLS-1$
+            }
+            String entryNameValue = value;
+
+            Attributes entry = entries.get(entryNameValue);
+            if (entry == null) {
+                entry = new Attributes(12);
+            }
+
+            while (readHeader()) {
+                entry.put(name, value);
+            }
+
+            if (chunks != null) {
+                if (chunks.get(entryNameValue) != null) {
+                    // TODO A bug: there might be several verification chunks for
+                    // the same name. I believe they should be used to update
+                    // signature in order of appearance; there are two ways to fix
+                    // this: either use a list of chunks, or decide on used
+                    // signature algorithm in advance and reread the chunks while
+                    // updating the signature; for now a defensive error is thrown
+                    throw new IOException("A jar verifier does not support more than one entry with the same name"); //$NON-NLS-1$
+                }
+                chunks.put(entryNameValue, new Manifest.Chunk(mark, pos));
+                mark = pos;
+            }
+
+            entries.put(entryNameValue, entry);
+        }
+    }
+
+    int getPos() {
+        return pos;
+    }
+
+    /**
+     * Number of subsequent line breaks.
+     */
+    int linebreak = 0;
+
+    /**
+     * Read a single line from the manifest buffer.
+     */
+    private boolean readHeader() throws IOException {
+        if (linebreak > 1) {
+            // break a section on an empty line
+            linebreak = 0;
+            return false;
+        }
+        readName();
+        linebreak = 0;
+        readValue();
+        // if the last line break is missed, the line
+        // is ignored by the reference implementation
+        return linebreak > 0;
+    }
+
+    private byte[] wrap(int mark, int pos) {
+        byte[] buffer = new byte[pos - mark];
+        System.arraycopy(buf, mark, buffer, 0, pos - mark);
+        return buffer;
+    }
+
+    private void readName() throws IOException {
+        int i = 0;
+        int mark = pos;
+
+        while (pos < buf.length) {
+            byte b = buf[pos++];
+
+            if (b == ':') {
+                byte[] nameBuffer = wrap(mark, pos - 1);
+
+                if (buf[pos++] != ' ') {
+                    throw new IOException(
+                            "Invalid attribute " + Arrays.toString(nameBuffer)); //$NON-NLS-1$
+                }
+
+                name = new Attributes.Name(nameBuffer);
+                return;
+            }
+
+            if (!((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_'
+                    || b == '-' || (b >= '0' && b <= '9'))) {
+                throw new IOException("Invalid attribute " + b); //$NON-NLS-1$
+            }
+        }
+        if (i > 0) {
+            throw new IOException(
+                    "Invalid attribute " + Arrays.toString(wrap(mark, buf.length))); //$NON-NLS-1$
+        }
+    }
+
+    private void readValue() throws IOException {
+        byte next;
+        boolean lastCr = false;
+        int mark = pos;
+        int last = pos;
+
+        decoder.reset();
+        cBuf.clear();
+
+        while (pos < buf.length) {
+            next = buf[pos++];
+
+            switch (next) {
+            case 0:
+                throw new IOException("NUL character in a manifest"); //$NON-NLS-1$
+            case '\n':
+                if (lastCr) {
+                    lastCr = false;
+                } else {
+                    linebreak++;
+                }
+                continue;
+            case '\r':
+                lastCr = true;
+                linebreak++;
+                continue;
+            case ' ':
+                if (linebreak == 1) {
+                    decode(mark, last, false);
+                    mark = pos;
+                    last = mark;
+                    linebreak = 0;
+                    continue;
+                }
+            }
+
+            if (linebreak >= 1) {
+                pos--;
+                break;
+            }
+            last = pos;
+        }
+
+        decode(mark, last, true);
+        while (CoderResult.OVERFLOW == decoder.flush(cBuf)) {
+            enlargeBuffer();
+        }
+        value = new String(cBuf.array(), cBuf.arrayOffset(), cBuf.position());
+    }
+
+    private void decode(int mark, int pos, boolean endOfInput)
+            throws IOException {
+        ByteBuffer bBuf = ByteBuffer.wrap(buf, mark, pos - mark);
+        while (CoderResult.OVERFLOW == decoder.decode(bBuf, cBuf, endOfInput)) {
+            enlargeBuffer();
+        }
+    }
+
+    private void enlargeBuffer() {
+        CharBuffer newBuf = CharBuffer.allocate(cBuf.capacity() * 2);
+        newBuf.put(cBuf.array(), cBuf.arrayOffset(), cBuf.position());
+        cBuf = newBuf;
+        ThreadLocalCache.charBuffer.set(cBuf);
+    }
+}

--- a/src/main/java/org/codehaus/plexus/archiver/jar/harmony/Manifest.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/harmony/Manifest.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.plexus.archiver.jar.harmony;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The {@code Manifest} class is used to obtain attribute information for a
+ * {@code JarFile} and its entries.
+ */
+public class Manifest implements Cloneable {
+    static final int LINE_LENGTH_LIMIT = 72;
+
+    private static final byte[] LINE_SEPARATOR = new byte[] { '\r', '\n' };
+
+    private static final byte[] VALUE_SEPARATOR = new byte[] { ':', ' ' };
+
+    private static final Attributes.Name NAME_ATTRIBUTE = new Attributes.Name(
+            "Name"); //$NON-NLS-1$
+
+    private Attributes mainAttributes = new Attributes();
+
+    private Map<String, Attributes> entries = new LinkedHashMap<String, Attributes>();
+
+    static class Chunk {
+        int start;
+        int end;
+
+        Chunk(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+    }
+
+    private LinkedHashMap<String, Chunk> chunks;
+
+    /**
+     * Manifest bytes are used for delayed entry parsing.
+     */
+    private InitManifest im;
+
+    /**
+     * Creates a new {@code Manifest} instance.
+     */
+    public Manifest() {
+        super();
+    }
+
+    /**
+     * Creates a new {@code Manifest} instance using the attributes obtained
+     * from the input stream.
+     *
+     * @param is
+     *            {@code InputStream} to parse for attributes.
+     * @throws IOException
+     *             if an IO error occurs while creating this {@code Manifest}
+     */
+    public Manifest(InputStream is) throws IOException {
+        super();
+        read(is);
+    }
+
+    /**
+     * Creates a new {@code Manifest} instance. The new instance will have the
+     * same attributes as those found in the parameter {@code Manifest}.
+     *
+     * @param man
+     *            {@code Manifest} instance to obtain attributes from.
+     */
+    @SuppressWarnings("unchecked")
+    public Manifest(Manifest man) {
+        mainAttributes = (Attributes) man.mainAttributes.clone();
+        entries = (LinkedHashMap<String, Attributes>) ((LinkedHashMap<String, Attributes>) man
+                .getEntries()).clone();
+    }
+
+    /**
+     * Returns the {@code Attributes} associated with the parameter entry
+     * {@code name}.
+     *
+     * @param name
+     *            the name of the entry to obtain {@code Attributes} from.
+     * @return the Attributes for the entry or {@code null} if the entry does
+     *         not exist.
+     */
+    public Attributes getAttributes(String name) {
+        return getEntries().get(name);
+    }
+
+    /**
+     * Returns a map containing the {@code Attributes} for each entry in the
+     * {@code Manifest}.
+     *
+     * @return the map of entry attributes.
+     */
+    public Map<String, Attributes> getEntries() {
+        return entries;
+    }
+
+    /**
+     * Returns the main {@code Attributes} of the {@code JarFile}.
+     *
+     * @return main {@code Attributes} associated with the source {@code
+     *         JarFile}.
+     */
+    public Attributes getMainAttributes() {
+        return mainAttributes;
+    }
+
+    /**
+     * Creates a copy of this {@code Manifest}. The returned {@code Manifest}
+     * will equal the {@code Manifest} from which it was cloned.
+     *
+     * @return a copy of this instance.
+     */
+    @Override
+    public Object clone() {
+        return new Manifest(this);
+    }
+
+    /**
+     * Writes out the attribute information of the receiver to the specified
+     * {@code OutputStream}.
+     *
+     * @param os
+     *            The {@code OutputStream} to write to.
+     * @throws IOException
+     *             If an error occurs writing the {@code Manifest}.
+     */
+    public void write(OutputStream os) throws IOException {
+        write(this, os);
+    }
+
+    /**
+     * Constructs a new {@code Manifest} instance obtaining attribute
+     * information from the specified input stream.
+     *
+     * @param is
+     *            The {@code InputStream} to read from.
+     * @throws IOException
+     *             If an error occurs reading the {@code Manifest}.
+     */
+    public void read(InputStream is) throws IOException {
+        byte[] buf = readFully(is);
+
+        if (buf.length == 0) {
+            return;
+        }
+
+        // a workaround for HARMONY-5662
+        // replace EOF and NUL with another new line
+        // which does not trigger an error
+        byte b = buf[buf.length - 1];
+        if (0 == b || 26 == b) {
+            buf[buf.length - 1] = '\n';
+        }
+
+        // Attributes.Name.MANIFEST_VERSION is not used for
+        // the second parameter for RI compatibility
+        im = new InitManifest(buf, mainAttributes, null);
+        // FIXME
+        im.initEntries(entries, chunks);
+        im = null;
+    }
+
+    /*
+     * Helper to read the entire contents of the manifest from the
+     * given input stream.  Usually we can do this in a single read
+     * but we need to account for 'infinite' streams, by ensuring we
+     * have a line feed within a reasonable number of characters.
+     */
+    private byte[] readFully(InputStream is) throws IOException {
+        // Initial read
+        byte[] buffer = new byte[4096];
+        int count = is.read(buffer);
+        int nextByte = is.read();
+
+        // Did we get it all in one read?
+        if (nextByte == -1) {
+            byte[] dest = new byte[count];
+            System.arraycopy(buffer, 0, dest, 0, count);
+            return dest;
+        }
+
+        // Does it look like a manifest?
+        if (!containsLine(buffer, count)) {
+            // archive.2E=Manifest is too long
+            throw new IOException("Manifest is too long"); //$NON-NLS-1$
+        }
+
+        // Requires additional reads
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(count * 2);
+        baos.write(buffer, 0, count);
+        baos.write(nextByte);
+        while (true) {
+            count = is.read(buffer);
+            if (count == -1) {
+                return baos.toByteArray();
+            }
+            baos.write(buffer, 0, count);
+        }
+    }
+
+    /*
+     * Check to see if the buffer contains a newline or carriage
+     * return character within the first 'length' bytes.  Used to
+     * check the validity of the manifest input stream.
+     */
+    private boolean containsLine(byte[] buffer, int length) {
+        for (int i = 0; i < length; i++) {
+            if (buffer[i] == 0x0A || buffer[i] == 0x0D) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the hash code for this instance.
+     *
+     * @return this {@code Manifest}'s hashCode.
+     */
+    @Override
+    public int hashCode() {
+        return mainAttributes.hashCode() ^ getEntries().hashCode();
+    }
+
+    /**
+     * Determines if the receiver is equal to the parameter object. Two {@code
+     * Manifest}s are equal if they have identical main attributes as well as
+     * identical entry attributes.
+     *
+     * @param o
+     *            the object to compare against.
+     * @return {@code true} if the manifests are equal, {@code false} otherwise
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o.getClass() != this.getClass()) {
+            return false;
+        }
+        if (!mainAttributes.equals(((Manifest) o).mainAttributes)) {
+            return false;
+        }
+        return getEntries().equals(((Manifest) o).getEntries());
+    }
+
+    /**
+     * Writes out the attribute information of the specified manifest to the
+     * specified {@code OutputStream}
+     *
+     * @param manifest
+     *            the manifest to write out.
+     * @param out
+     *            The {@code OutputStream} to write to.
+     * @throws IOException
+     *             If an error occurs writing the {@code Manifest}.
+     */
+    static void write(Manifest manifest, OutputStream out) throws IOException {
+        CharsetEncoder encoder = ThreadLocalCache.utf8Encoder.get();
+        ByteBuffer buffer = ThreadLocalCache.byteBuffer.get();
+
+        String version = manifest.mainAttributes
+                .getValue(Attributes.Name.MANIFEST_VERSION);
+        if (version != null) {
+            writeEntry(out, Attributes.Name.MANIFEST_VERSION, version, encoder,
+                    buffer);
+            Iterator<?> entries = manifest.mainAttributes.keySet().iterator();
+            while (entries.hasNext()) {
+                Attributes.Name name = (Attributes.Name) entries.next();
+                if (!name.equals(Attributes.Name.MANIFEST_VERSION)) {
+                    writeEntry(out, name, manifest.mainAttributes
+                            .getValue(name), encoder, buffer);
+                }
+            }
+        }
+        out.write(LINE_SEPARATOR);
+        Iterator<String> i = manifest.getEntries().keySet().iterator();
+        while (i.hasNext()) {
+            String key = i.next();
+            writeEntry(out, NAME_ATTRIBUTE, key, encoder, buffer);
+            Attributes attrib = manifest.entries.get(key);
+            Iterator<?> entries = attrib.keySet().iterator();
+            while (entries.hasNext()) {
+                Attributes.Name name = (Attributes.Name) entries.next();
+                writeEntry(out, name, attrib.getValue(name), encoder, buffer);
+            }
+            out.write(LINE_SEPARATOR);
+        }
+    }
+
+    private static void writeEntry(OutputStream os, Attributes.Name name,
+            String value, CharsetEncoder encoder, ByteBuffer bBuf)
+            throws IOException {
+        byte[] out = name.getBytes();
+        if (out.length > LINE_LENGTH_LIMIT) {
+            throw new IOException(
+                    "A length of the encoded header name \"" + name + "\" exceeded maximum length " + Integer.valueOf(LINE_LENGTH_LIMIT)); //$NON-NLS-1$
+        }
+
+        os.write(out);
+        os.write(VALUE_SEPARATOR);
+
+        encoder.reset();
+        bBuf.clear().limit(LINE_LENGTH_LIMIT - out.length - 2);
+
+        CharBuffer cBuf = CharBuffer.wrap(value);
+        CoderResult r;
+
+        while (true) {
+            r = encoder.encode(cBuf, bBuf, true);
+            if (CoderResult.UNDERFLOW == r) {
+                r = encoder.flush(bBuf);
+            }
+            os.write(bBuf.array(), bBuf.arrayOffset(), bBuf.position());
+            os.write(LINE_SEPARATOR);
+            if (CoderResult.UNDERFLOW == r) {
+                break;
+            }
+            os.write(' ');
+            bBuf.clear().limit(LINE_LENGTH_LIMIT - 1);
+        }
+    }
+}

--- a/src/main/java/org/codehaus/plexus/archiver/jar/harmony/ThreadLocalCache.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/harmony/ThreadLocalCache.java
@@ -1,0 +1,95 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.codehaus.plexus.archiver.jar.harmony;
+
+import java.lang.ref.SoftReference;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+
+/**
+ * The class extends the functionality of {@link java.lang.ThreadLocal} with
+ * possibility of discarding the thread local storage content when a heap is
+ * exhausted.
+ */
+public class ThreadLocalCache<T> {
+
+    private SoftReference<ThreadLocal<T>> storage = new SoftReference<ThreadLocal<T>>(
+            null);
+
+    private ThreadLocal<T> getThreadLocal() {
+        ThreadLocal<T> tls = storage.get();
+        if (tls == null) {
+            tls = new ThreadLocal<T>() {
+                public T initialValue() {
+                    return ThreadLocalCache.this.initialValue();
+                }
+            };
+            storage = new SoftReference<ThreadLocal<T>>(tls);
+        }
+        return tls;
+    }
+
+    /**
+     * Returns the initial value for the cache for the current thread.
+     */
+    protected T initialValue() {
+        return null;
+    }
+
+    /**
+     * Returns the thread local value of this object.
+     */
+    public T get() {
+        return getThreadLocal().get();
+    }
+
+    /**
+     * Sets the value of this variable for the current thread. Might be useful
+     * for expanding the thread local cache.
+     */
+    public void set(T value) {
+        getThreadLocal().set(value);
+    }
+
+    public static ThreadLocalCache<CharsetDecoder> utf8Decoder = new ThreadLocalCache<CharsetDecoder>() {
+        protected CharsetDecoder initialValue() {
+            return Charset.forName("UTF-8").newDecoder();
+        }
+    };
+
+    public static ThreadLocalCache<CharsetEncoder> utf8Encoder = new ThreadLocalCache<CharsetEncoder>() {
+        protected CharsetEncoder initialValue() {
+            return Charset.forName("UTF-8").newEncoder();
+        }
+    };
+
+    public static ThreadLocalCache<java.nio.ByteBuffer> byteBuffer = new ThreadLocalCache<java.nio.ByteBuffer>() {
+        protected java.nio.ByteBuffer initialValue() {
+            return java.nio.ByteBuffer.allocate(72); // >=
+            // Manifest.LINE_LENGTH_LIMIT
+        }
+    };
+
+    public static ThreadLocalCache<CharBuffer> charBuffer = new ThreadLocalCache<CharBuffer>() {
+        protected CharBuffer initialValue() {
+            return CharBuffer.allocate(72); // no specific requirement
+        }
+    };
+}

--- a/src/main/java/org/codehaus/plexus/archiver/jar/harmony/Util.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/harmony/Util.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.plexus.archiver.jar.harmony;
+
+/**
+ * Helpers for the archive module.
+ */
+public class Util {
+
+    /**
+     * Compares the given byte arrays and returns whether they are equal,
+     * ignoring case differences and assuming they are ascii-encoded strings.
+     * 
+     * @param buf1
+     *            first byte array to compare.
+     * @param buf2
+     *            second byte array to compare.
+     * @return the result of the comparison.
+     */
+    public static boolean asciiEqualsIgnoreCase(byte[] buf1, byte[] buf2) {
+        if (buf1 == null || buf2 == null) {
+            return false;
+        }
+        if (buf1 == buf2) {
+            return true;
+        }
+        if (buf1.length != buf2.length) {
+            return false;
+        }
+
+        for (int i = 0; i < buf1.length; i++) {
+            byte b1 = buf1[i];
+            byte b2 = buf2[i];
+            if (b1 != b2 && toASCIIUpperCase(b1) != toASCIIUpperCase(b2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static final byte toASCIIUpperCase(byte b) {
+        if ('a' <= b && b <= 'z') {
+            return (byte) (b - ('a' - 'A'));
+        }
+        return b;
+    }
+}

--- a/src/test/java/org/codehaus/plexus/archiver/jar/JdkManifestFactoryTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/jar/JdkManifestFactoryTest.java
@@ -3,9 +3,9 @@ package org.codehaus.plexus.archiver.jar;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.archiver.jar.harmony.Attributes;
+import org.codehaus.plexus.archiver.jar.harmony.Manifest;
 import org.codehaus.plexus.archiver.util.Streams;
 
 /**
@@ -94,7 +94,7 @@ public class JdkManifestFactoryTest
     /**
      * Reads a Manifest file.
      */
-    private java.util.jar.Manifest getManifest( String filename )
+    private org.codehaus.plexus.archiver.jar.harmony.Manifest getManifest( String filename )
         throws IOException, ManifestException
     {
         try ( InputStream r = Streams.fileInputStream( getTestFile( filename ) ) )

--- a/src/test/java/org/codehaus/plexus/archiver/jar/ManifestTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/jar/ManifestTest.java
@@ -20,8 +20,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.jar.Attributes;
 import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.archiver.jar.harmony.Attributes;
 
 /**
  * @author Emmanuel Venisse
@@ -215,16 +215,16 @@ public class ManifestTest
     public void testGetDefaultManifest()
         throws Exception
     {
-        java.util.jar.Manifest mf = Manifest.getDefaultManifest();
-        java.util.jar.Attributes mainAttributes = mf.getMainAttributes();
+        org.codehaus.plexus.archiver.jar.harmony.Manifest mf = Manifest.getDefaultManifest();
+        org.codehaus.plexus.archiver.jar.harmony.Attributes mainAttributes = mf.getMainAttributes();
         assertEquals( 2, mainAttributes.size() );
-        assertTrue( mainAttributes.containsKey( new java.util.jar.Attributes.Name( "Manifest-Version" ) ) );
-        assertTrue( mainAttributes.containsKey( new java.util.jar.Attributes.Name( "Created-By" ) ) );
+        assertTrue( mainAttributes.containsKey( new org.codehaus.plexus.archiver.jar.harmony.Attributes.Name( "Manifest-Version" ) ) );
+        assertTrue( mainAttributes.containsKey( new org.codehaus.plexus.archiver.jar.harmony.Attributes.Name( "Created-By" ) ) );
 
         mf = Manifest.getDefaultManifest( true );
         mainAttributes = mf.getMainAttributes();
         assertEquals( 1, mainAttributes.size() );
-        assertTrue( mainAttributes.containsKey( new java.util.jar.Attributes.Name( "Manifest-Version" ) ) );
+        assertTrue( mainAttributes.containsKey( new org.codehaus.plexus.archiver.jar.harmony.Attributes.Name( "Manifest-Version" ) ) );
     }
 
     public void checkMultiLineAttribute( String in, String expected )


### PR DESCRIPTION
Unfortunately the standard Java implementations are not reproducible. In order to aid build reproducibility we use our own implementations with stable collections.

This is certainly a very icky approach, but short of implementing our own manifest parser (or doing basic sorting after the fact) this is the only way we can get reproducible builds (see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=74682318).

Harmony was chosen as it was the only already existing, Apache licensed manifest parser I could find.