### PR TITLE
Fix unjustified warning about casing for directory entries

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -405,8 +405,13 @@ public abstract class AbstractUnArchiver
             return true;
         }
 
+        boolean entryIsDirectory = entryName.endsWith( "/" ); // directory entries always end with '/', regardless of the OS.
         String canonicalDestPath = targetFileName.getCanonicalPath();
-        String relativeCanonicalDestPath = canonicalDestPath.replace( targetDirectory.getCanonicalPath() + File.separatorChar, "" );
+        String suffix = (entryIsDirectory ? "/" : "");
+        String relativeCanonicalDestPath = canonicalDestPath.replace(
+                targetDirectory.getCanonicalPath() + File.separatorChar,
+                "" )
+                + suffix;
         boolean fileOnDiskIsNewerThanEntry = targetFileName.lastModified() >= entryDate.getTime();
         boolean differentCasing = !entryName.equals( relativeCanonicalDestPath );
 

--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -33,7 +33,8 @@ import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Unit test for {@link AbstractUnArchiver}
@@ -182,6 +183,21 @@ public class AbstractUnArchiverTest
         this.abstractUnArchiver.setOverwrite( false );
         assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is( false ) );
         assertThat( this.log.getWarns(), hasItem( new LogMessageMatcher( "names differ only by case" ) ) );
+    }
+
+    @Test
+    public void shouldNotWarnAboutDifferentCasingForDirectoryEntries() throws IOException
+    {
+        // given
+        File file = temporaryFolder.newFolder();
+        file.setLastModified( 0 );
+        String entryname = file.getName() + '/'; // archive entries for directories end with a '/'
+        Date entryDate = new Date();
+
+        // when & then
+        this.abstractUnArchiver.setOverwrite( true );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is( true ) );
+        assertThat( this.log.getWarns(), not( hasItem( new LogMessageMatcher( "names differ only by case" ) ) ) );
     }
 
     static class LogMessageMatcher extends BaseMatcher<CapturingLog.Message> {


### PR DESCRIPTION
Follow-up for #128, where we omitted the case that an archive entry could be a directory. In that case, its name will end with `/`, but the canonical target path will not have the `/` suffix. This would be seen as a difference in casing, but that is not true.