### PR TITLE
Check for negative millisecond offset

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -373,7 +373,11 @@ public abstract class AbstractUnArchiver
                 }
             }
 
-            targetFileName.setLastModified( entryDate.getTime() );
+            final long millis = entryDate.getTime();
+            if ( millis >= 0 )
+            {
+                targetFileName.setLastModified( millis );
+            }
 
             if ( !isIgnorePermissions() && mode != null && !isDirectory )
             {


### PR DESCRIPTION
File.setLastModified() does not allow negative values, but those
can be present in Date. One such source is ZipEntry.getTime(), which
returns -1 to indicate a non-applicable time. Fixes #170.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
