### PR TITLE
Remove native `chmod` tool execution in tests

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarFileAttributesTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarFileAttributesTest.java
@@ -9,6 +9,7 @@ import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.util.DefaultArchivedFileSet;
+import org.codehaus.plexus.components.io.attributes.AttributeUtils;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributeUtils;
 import org.codehaus.plexus.components.io.attributes.PlexusIoResourceAttributes;
 import org.codehaus.plexus.util.FileUtils;
@@ -87,8 +88,7 @@ public class TarFileAttributesTest
             writer.write( "This is a test file." );
         }
 
-        int result = Runtime.getRuntime().exec( "chmod 440 " + tempFile.getAbsolutePath() ).waitFor();
-        assertEquals( 0, result );
+        AttributeUtils.chmod(tempFile, 0440);
 
         TarArchiver tarArchiver = getPosixCompliantTarArchiver();
 
@@ -153,9 +153,7 @@ public class TarFileAttributesTest
             writer.write( "This is a test file." );
         }
 
-        int result = Runtime.getRuntime().exec( "chmod 440 " + tempFile.getAbsolutePath() ).waitFor();
-
-        assertEquals( 0, result );
+        AttributeUtils.chmod(tempFile, 0440);
 
         PlexusIoResourceAttributes fileAttributes = PlexusIoResourceAttributeUtils.getFileAttributes( tempFile );
 
@@ -214,8 +212,7 @@ public class TarFileAttributesTest
             writer.write( "This is a test file." );
         }
 
-        int result = Runtime.getRuntime().exec( "chmod 440 " + tempFile.getAbsolutePath() ).waitFor();
-        assertEquals( 0, result );
+        AttributeUtils.chmod(tempFile, 0440);
 
         TarArchiver tarArchiver = getPosixCompliantTarArchiver();
 
@@ -272,8 +269,7 @@ public class TarFileAttributesTest
             writer.write( "This is a test file." );
         }
 
-        int result = Runtime.getRuntime().exec( "chmod 440 " + tempFile.getAbsolutePath() ).waitFor();
-        assertEquals( 0, result );
+        AttributeUtils.chmod(tempFile, 0440);
 
         TarArchiver tarArchiver = getPosixCompliantTarArchiver();
 


### PR DESCRIPTION
`Runtime.getRuntime().exec( "chmod 440 " + ` causes
security warnings because it concatenates arguments
(there is a risk of argument injection).

The argument does not come from untrusted source,
but as we can use Java to change a file mode, it is
better to remove the `chmod` invocation altogether.
`chmod` was necessary before Java 7 as there
was no support for changing file modes.