### PR TITLE
Ensure that if entryName contains / char they are replaced by "File.separator"

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -409,7 +409,7 @@ public abstract class AbstractUnArchiver
                 "" )
                 + suffix;
         boolean fileOnDiskIsNewerThanEntry = targetFileName.lastModified() >= entryDate.getTime();
-        boolean differentCasing = !entryName.equals( relativeCanonicalDestPath );
+        boolean differentCasing = !entryName.replace("/", File.separator).equals( relativeCanonicalDestPath );
 
         String casingMessage = String.format( "Archive entry '%s' and existing file '%s' names differ only by case."
                 + " This may lead to an unexpected outcome on case-insensitive filesystems.", entryName, canonicalDestPath );

--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -200,6 +200,22 @@ public class AbstractUnArchiverTest
         assertThat( this.log.getWarns(), not( hasItem( new LogMessageMatcher( "names differ only by case" ) ) ) );
     }
 
+
+    @Test
+    public void shouldExtractWhenCasingDifferOnlyInEntryNamePath() throws IOException
+    {
+        // given
+        File file = new File( temporaryFolder.getRoot() + File.separator + "folder", "whatever.txt" ); // does not create the file!
+        file.mkdirs();
+        file.createNewFile();
+        String entryname = "folder/whatever.txt";
+        Date entryDate = new Date(System.currentTimeMillis()+5000);
+
+        // when & then
+        this.abstractUnArchiver.setOverwrite( true );
+        assertThat( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder.getRoot(), file, entryname, entryDate ), is ( true ) );
+    }
+
     static class LogMessageMatcher extends BaseMatcher<CapturingLog.Message> {
         private final StringContains delegateMatcher;
 

--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -205,10 +205,10 @@ public class AbstractUnArchiverTest
     public void shouldExtractWhenCasingDifferOnlyInEntryNamePath() throws IOException
     {
         // given
-        File file = new File( temporaryFolder.getRoot() + File.separator + "folder", "whatever.txt" ); // does not create the file!
+        File file = new File( temporaryFolder.getRoot() + File.separator + "directory", "whatever.txt" ); // does not create the file!
         file.mkdirs();
         file.createNewFile();
-        String entryname = "folder/whatever.txt";
+        String entryname = "directory/whatever.txt";
         Date entryDate = new Date(System.currentTimeMillis()+5000);
 
         // when & then


### PR DESCRIPTION
Since updating to plexus archiver 4.2.5 (from version 2) we have seen those warning:
[WARNING] Archive entry 'META-INF/MANIFEST.MF' and existing file 'C:\Dev\rt\master\tomcat\webapps\jahia\META-INF\MANIFEST.MF' names differ only by case. This may lead to an unexpected outcome on case-insensitive filesystems.

Issue here is that the AbtractUnArchiver assumes entryName is just a file but in a ZipArchive entryName can be a path and so when evaluating if we should extract, we should replace "/" char (Zip always use "/" by spec) by the File OS separator 