### PR TITLE
Do not add directories/files ending with .jar to the index

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
@@ -685,13 +685,17 @@ public class JarArchiver
                 dir = dir.substring( 0, pos );
             }
 
-            // name newline
-            writer.println( dir );
+            if ( !dir.endsWith(".jar") ) {
+                // name newline
+                writer.println( dir );
+            }
         }
 
         for ( String file : files )
         {
-            writer.println( file );
+            if ( !file.endsWith(".jar") ) {
+                writer.println( file );
+            }
         }
     }
 


### PR DESCRIPTION
Add directories/files ending with .jar to the index breaks parsing the index. E.g. The PostgreSQL JDBC driver does contain such directories.