### PR TITLE
Fix UnArchiver#isOverwrite not working as expected

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -91,11 +91,14 @@ public class AbstractUnArchiverTest
         Date entryDate = new Date();
 
         // when & then
+        // always extract the file if it does not exist
+        assertTrue( abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
+        abstractUnArchiver.setOverwrite( false );
         assertTrue( abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
     }
 
     @Test
-    public void shouldNotExtractWhenFileOnDiskIsNewerThanEntryInArchive( @TempDir File temporaryFolder ) throws IOException
+    public void shouldExtractWhenFileOnDiskIsNewerThanEntryInArchive( @TempDir File temporaryFolder ) throws IOException
     {
         // given
         File file = new File( temporaryFolder, "whatever.txt" );
@@ -105,11 +108,14 @@ public class AbstractUnArchiverTest
         Date entryDate = new Date( 0 );
 
         // when & then
+        // if the file is newer than archive entry, extract only if overwrite is true (default)
+        assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
+        abstractUnArchiver.setOverwrite( false );
         assertFalse( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
     }
 
     @Test
-    public void shouldNotExtractWhenFileOnDiskIsNewerThanEntryInArchive_andWarnAboutDifferentCasing( @TempDir File temporaryFolder )
+    public void shouldExtractWhenFileOnDiskIsNewerThanEntryInArchive_andWarnAboutDifferentCasing( @TempDir File temporaryFolder )
         throws IOException
     {
         // given
@@ -120,7 +126,7 @@ public class AbstractUnArchiverTest
         Date entryDate = new Date( 0 );
 
         // when & then
-        assertFalse( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
+        assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
         assertTrue( this.abstractUnArchiver.casingMessageEmitted.get() > 0 );
     }
 
@@ -135,12 +141,10 @@ public class AbstractUnArchiverTest
         Date entryDate = new Date( System.currentTimeMillis() );
 
         // when & then
-        this.abstractUnArchiver.setOverwrite( true );
+        // always extract the file if the archive entry is newer than the file on disk
         assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
-
-        // when & then
         this.abstractUnArchiver.setOverwrite( false );
-        assertFalse( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
+        assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
     }
 
     @Test
@@ -158,7 +162,7 @@ public class AbstractUnArchiverTest
         this.abstractUnArchiver.setOverwrite( true );
         assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
         this.abstractUnArchiver.setOverwrite( false );
-        assertFalse( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
+        assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
         assertTrue( this.abstractUnArchiver.casingMessageEmitted.get() > 0 );
     }
 


### PR DESCRIPTION
Regression in efd980d changed the way `UnArchiver#isOverwrite` flag work.
It is indented to indicate that `UnArchiver` should always override the existing entries.
efd980d changed it to indicate whether existing file should be overridden if the entry is newer, while in this case the file should be always overridden.

This commit returns the old behavior: if the entry is newer, override the existing file; if the entry is older, override the existing file only if isOverwrite is true.

Fixes: #228