### PR TITLE
keep file/directory permissions in Reproducible Builds mode

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -1283,12 +1283,7 @@ public abstract class AbstractArchiver
         // 2. sort filenames in each directory when scanning filesystem
         setFilenameComparator( String::compareTo );
 
-        // 3. ignore file/directory mode from filesystem, since they may vary based on local user umask
-        // notice: this overrides execute bit on Unix (that is already ignored on Windows)
-        setFileMode( Archiver.DEFAULT_FILE_MODE );
-        setDirectoryMode( Archiver.DEFAULT_DIR_MODE );
-
-        // 4. ignore uid/gid from filesystem (for tar)
+        // 3. ignore uid/gid from filesystem (for tar)
         setOverrideUid( 0 );
         setOverrideUserName( "root" ); // is it possible to avoid this, like "tar --numeric-owner"?
         setOverrideGid( 0 );

--- a/src/main/java/org/codehaus/plexus/archiver/Archiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/Archiver.java
@@ -488,7 +488,6 @@ public interface Archiver
      * <ul>
      * <li>reproducible archive entries order,</li>
      * <li>defined entries timestamp</li>
-     * <li>and reproducible entries Unix mode.</li>
      * </ul>
      *
      * @param lastModifiedTime The last modification time of the entries


### PR DESCRIPTION
undo part of #121 that is causing issues for maven-assembly-plugin users, see https://issues.apache.org/jira/browse/MASSEMBLY-941