### PR TITLE
Normalize file separators before warning about equal archive entries

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractUnArchiver.java
@@ -426,7 +426,7 @@ public abstract class AbstractUnArchiver
                 "" )
                 + suffix;
         boolean fileOnDiskIsOlderThanEntry = targetFileName.lastModified() < entryDate.getTime();
-        boolean differentCasing = !entryName.equals( relativeCanonicalDestPath );
+        boolean differentCasing = !normalizedFileSeparator( entryName ).equals( normalizedFileSeparator( relativeCanonicalDestPath ) );
 
         // Warn for case (4) and (5) if the file system is case-insensitive
         if ( differentCasing )
@@ -440,5 +440,8 @@ public abstract class AbstractUnArchiver
         // Override the existing file if isOverwrite() is true or if the file on disk is older than the one in the archive
         return isOverwrite() || fileOnDiskIsOlderThanEntry;
     }
-
+    
+    private String normalizedFileSeparator(String pathOrEntry) {
+    	return pathOrEntry.replace("/", File.separator);
+    }
 }

--- a/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/AbstractUnArchiverTest.java
@@ -182,4 +182,21 @@ public class AbstractUnArchiverTest
         assertTrue( this.abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryname, entryDate ) );
         assertEquals( 0, this.abstractUnArchiver.casingMessageEmitted.get() );
     }
+
+    @Test
+    public void shouldExtractWhenCasingDifferOnlyInEntryNamePath( @TempDir File temporaryFolder)
+            throws IOException
+    {
+        // given
+        String entryName = "directory/whatever.txt";
+        File file = new File( temporaryFolder, entryName ); // does not create the file!
+        file.mkdirs();
+        file.createNewFile();
+        Date entryDate = new Date(System.currentTimeMillis() + 5000);
+
+        // when & then
+        abstractUnArchiver.setOverwrite( true );
+        assertTrue( abstractUnArchiver.shouldExtractEntry( temporaryFolder, file, entryName, entryDate ) );
+        assertEquals(0, abstractUnArchiver.casingMessageEmitted.get());
+    }
 }


### PR DESCRIPTION
Fixes #248.