### PR TITLE
Deprecate the JAR Index feature (JDK-8302819)

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarArchiver.java
@@ -64,7 +64,10 @@ public class JarArchiver
 
     /**
      * The index file name.
+     *
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     private static final String INDEX_NAME = "META-INF/INDEX.LIST";
 
     /**
@@ -120,7 +123,10 @@ public class JarArchiver
 
     /**
      * jar index is JDK 1.3+ only
+     *
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     private boolean index = false;
 
     /**
@@ -140,7 +146,10 @@ public class JarArchiver
 
     /**
      * Path containing jars that shall be indexed in addition to this archive.
+     *
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     private List<String> indexJars;
 
     /**
@@ -164,7 +173,9 @@ public class JarArchiver
      * This may speed up classloading in some cases.
      *
      * @param flag true to create an index
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     public void setIndex( boolean flag )
     {
         index = flag;
@@ -291,7 +302,9 @@ public class JarArchiver
 
     /**
      * @param indexJar The indexjar
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     public void addConfiguredIndexJars( File indexJar )
     {
         if ( indexJars == null )
@@ -402,7 +415,9 @@ public class JarArchiver
      * @throws IOException thrown if there is an error while creating the
      * index and adding it to the zip stream.
      * @throws org.codehaus.plexus.archiver.ArchiverException
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     private void createIndexList( ConcurrentJarCreator zOut )
         throws IOException, ArchiverException
     {
@@ -657,7 +672,9 @@ public class JarArchiver
      * @param dirs The directories
      * @param files The files
      * @param writer The printwriter ;)
+     * @deprecated See <a href="https://bugs.openjdk.org/browse/JDK-8302819">JDK-8302819</a>
      */
+    @Deprecated
     protected final void writeIndexLikeList( List<String> dirs, List<String> files, PrintWriter writer )
     {
         // JarIndex is sorting the directories by ascending order.


### PR DESCRIPTION
The JAR Index mechanism is a legacy optimization from early JDK releases to allow downloading of JAR files to be postponed when loading applets or other classes over the network. The feature has been disabled by default since Java 18. Time has come to remove the feature from the Java runtime and also to add a warning to the jar tool when the -i/--generate-index option is used.

See: https://bugs.openjdk.org/browse/JDK-8305597