### PR TITLE
Override project.url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
   <version>4.7.2-SNAPSHOT</version>
   <name>Plexus Archiver Component</name>
 
+  <url>https://codehaus-plexus.github.io/plexus-archiver/</url>
+
   <scm>
     <connection>scm:git:https://github.com/codehaus-plexus/plexus-archiver.git</connection>
     <developerConnection>scm:git:https://github.com/codehaus-plexus/plexus-archiver.git</developerConnection>


### PR DESCRIPTION
Default inheritance add project artifact to parent url ... 
and we have wrong result like `https://codehaus-plexus.github.io/plexus-pom/plexus-archiver/`