### PR TITLE
Remove parent and reports menu from site

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -6,10 +6,6 @@
       <item name="Introduction" href="index.html"/>
       <item name="JavaDocs" href="apidocs/index.html"/>
       <item name="Source Xref" href="xref/index.html"/>
-      <!--item name="FAQ" href="faq.html"/-->
     </menu>
-
-    <menu ref="parent"/>
-    <menu ref="reports"/>
   </body>
 </project>


### PR DESCRIPTION
Parent menu generate wrong link ...
It is not important for project documentation we can simply remove it

Reports menu comes from parent