### PR TITLE
Remove junit-jupiter-engine from project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,11 +120,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4jVersion}</version>


### PR DESCRIPTION
We not need junit-jupiter-engine on tests classpath it will be added by surefire to provider classpath