### PR TITLE
#311 - provide fluent setter for usingDefaultExcludes flag in Abstrac…

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/util/AbstractFileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/util/AbstractFileSet.java
@@ -162,6 +162,12 @@ public abstract class AbstractFileSet<T extends AbstractFileSet> implements Base
         return (T) this;
     }
 
+    @SuppressWarnings("unchecked")
+    public T usingDefaultExcludes(boolean usingDefaultExcludes) {
+        setUsingDefaultExcludes(usingDefaultExcludes);
+        return (T) this;
+    }
+
     public void setStreamTransformer(@Nonnull InputStreamTransformer streamTransformer) {
         this.streamTransformer = streamTransformer;
     }

--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
@@ -449,8 +449,8 @@ class TarArchiverTest extends TestSupport {
         final File tarFile2 = getTestFile("target/output/pasymlinks-archivedFileset.tar");
         final TarArchiver tarArchiver = getPosixTarArchiver();
         tarArchiver.setDestFile(tarFile2);
-        DefaultArchivedFileSet archivedFileSet = DefaultArchivedFileSet.archivedFileSet(tarFile);
-        archivedFileSet.setUsingDefaultExcludes(false);
+        DefaultArchivedFileSet archivedFileSet =
+                DefaultArchivedFileSet.archivedFileSet(tarFile).usingDefaultExcludes(false);
         tarArchiver.addArchivedFileSet(archivedFileSet);
         tarArchiver.createArchive();
 

--- a/src/test/java/org/codehaus/plexus/archiver/util/DefaultFileSetTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/util/DefaultFileSetTest.java
@@ -16,11 +16,16 @@ class DefaultFileSetTest {
     void testCreate() {
         final String[] includes = {"zz", "yy"};
         final String[] exc = {"xx1", "xx2"};
-        final DefaultFileSet dfs =
-                fileSet(new File("foo")).prefixed("pfx").include(includes).exclude(exc);
+        final boolean usingDefaultExcludes = true;
+        final DefaultFileSet dfs = fileSet(new File("foo"))
+                .prefixed("pfx")
+                .include(includes)
+                .exclude(exc)
+                .usingDefaultExcludes(usingDefaultExcludes);
         assertEquals("foo", dfs.getDirectory().getName());
         assertEquals("pfx", dfs.getPrefix());
         assertEquals("zz", dfs.getIncludes()[0]);
         assertEquals("xx1", dfs.getExcludes()[0]);
+        assertEquals(usingDefaultExcludes, dfs.isUsingDefaultExcludes());
     }
 }


### PR DESCRIPTION
Addition of a fluent setter for usingDefaultExcludes flag in [AbstractFileSet](https://github.com/codehaus-plexus/plexus-archiver/issues/src/main/java/org/codehaus/plexus/archiver/util/AbstractFileSet.java).

Related issue: https://github.com/codehaus-plexus/plexus-archiver/issues/311