### PR TITLE
Fix modular jar final permissions

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/jar/JarToolModularJarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/jar/JarToolModularJarArchiver.java
@@ -22,8 +22,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileAttribute;
@@ -70,9 +70,6 @@ public class JarToolModularJarArchiver extends ModularJarArchiver {
     private static final String MODULE_DESCRIPTOR_FILE_NAME = "module-info.class";
 
     private static final Pattern MRJAR_VERSION_AREA = Pattern.compile("META-INF/versions/\\d+/");
-
-    private static final boolean IS_POSIX =
-            FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 
     private Object jarTool;
 
@@ -155,10 +152,11 @@ public class JarToolModularJarArchiver extends ModularJarArchiver {
     private void fixLastModifiedTimeZipEntries() throws IOException {
         long timeMillis = getLastModifiedTime().toMillis();
         Path destFile = getDestFile().toPath();
+        PosixFileAttributes posixFileAttributes = Files.getFileAttributeView(
+                        destFile, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS)
+                .readAttributes();
         FileAttribute<?>[] attributes;
-        if (IS_POSIX) {
-            PosixFileAttributes posixFileAttributes = Files.getFileAttributeView(destFile, PosixFileAttributeView.class)
-                    .readAttributes();
+        if (posixFileAttributes != null) {
             attributes = new FileAttribute<?>[1];
             attributes[0] = PosixFilePermissions.asFileAttribute(posixFileAttributes.permissions());
         } else {


### PR DESCRIPTION
When a new modular jar file is generated with maven-jar-plugin with Java 11, the final permissions of the file are restricted to the current user instead of using the environment umask which usually allows for group and other users to access the file as well.

This is caused by the use of Files#createTempFile() which has a restrictive file permission model for security reason but as the temporary file is generated next to the original jar file, and there's no sensitive reason to restrict its access, the restrictive file permission should not be needed.

Fix the issue by creating a simple temporary file generator method.

Fixes #332 