### PR TITLE
Change Snappy compressor to io.airlift:aircompressor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
       <version>${slf4jVersion}</version>
     </dependency>
     <dependency>
-      <groupId>org.iq80.snappy</groupId>
-      <artifactId>snappy</artifactId>
-      <version>0.4</version>
+      <groupId>io.airlift</groupId>
+      <artifactId>aircompressor</artifactId>
+      <version>0.27</version>
     </dependency>
     <dependency>
       <groupId>org.tukaani</groupId>

--- a/src/main/java/org/codehaus/plexus/archiver/snappy/SnappyCompressor.java
+++ b/src/main/java/org/codehaus/plexus/archiver/snappy/SnappyCompressor.java
@@ -18,9 +18,9 @@ package org.codehaus.plexus.archiver.snappy;
 
 import java.io.IOException;
 
+import io.airlift.compress.snappy.SnappyFramedOutputStream;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.util.Compressor;
-import org.iq80.snappy.SnappyFramedOutputStream;
 
 import static org.codehaus.plexus.archiver.util.Streams.bufferedOutputStream;
 import static org.codehaus.plexus.archiver.util.Streams.fileOutputStream;

--- a/src/main/java/org/codehaus/plexus/archiver/snappy/SnappyUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/snappy/SnappyUnArchiver.java
@@ -23,9 +23,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import io.airlift.compress.snappy.SnappyFramedInputStream;
 import org.codehaus.plexus.archiver.AbstractUnArchiver;
 import org.codehaus.plexus.archiver.ArchiverException;
-import org.iq80.snappy.SnappyFramedInputStream;
 
 import static org.codehaus.plexus.archiver.util.Streams.bufferedInputStream;
 import static org.codehaus.plexus.archiver.util.Streams.bufferedOutputStream;

--- a/src/main/java/org/codehaus/plexus/archiver/tar/TarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/tar/TarArchiver.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.zip.GZIPOutputStream;
 
+import io.airlift.compress.snappy.SnappyFramedOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
@@ -42,7 +43,6 @@ import org.codehaus.plexus.components.io.functions.SymlinkDestinationSupplier;
 import org.codehaus.plexus.components.io.resources.PlexusIoResource;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
-import org.iq80.snappy.SnappyOutputStream;
 
 import static org.codehaus.plexus.archiver.util.Streams.bufferedOutputStream;
 
@@ -426,7 +426,7 @@ public class TarArchiver extends AbstractArchiver {
         } else if (TarCompressionMethod.bzip2.equals(tarCompressionMethod)) {
             return new BZip2CompressorOutputStream(bufferedOutputStream(ostream));
         } else if (TarCompressionMethod.snappy.equals(tarCompressionMethod)) {
-            return new SnappyOutputStream(bufferedOutputStream(ostream));
+            return new SnappyFramedOutputStream(bufferedOutputStream(ostream));
         } else if (TarCompressionMethod.xz.equals(tarCompressionMethod)) {
             return new XZCompressorOutputStream(bufferedOutputStream(ostream));
         } else if (TarCompressionMethod.zstd.equals(tarCompressionMethod)) {

--- a/src/main/java/org/codehaus/plexus/archiver/tar/TarUnArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/tar/TarUnArchiver.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
 
+import io.airlift.compress.snappy.SnappyFramedInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -32,7 +33,6 @@ import org.codehaus.plexus.archiver.AbstractUnArchiver;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.util.Streams;
 import org.codehaus.plexus.components.io.filemappers.FileMapper;
-import org.iq80.snappy.SnappyFramedInputStream;
 
 import static org.codehaus.plexus.archiver.util.Streams.bufferedInputStream;
 import static org.codehaus.plexus.archiver.util.Streams.fileInputStream;


### PR DESCRIPTION
q80 Snappy is not actively maintained anymore. As quick fix users can upgrade to version 0.5, but in the long term users should prefer migrating to the Snappy implementation in https://github.com/airlift/aircompressor (version 0.27 or newer).

Superseded #336