### PR TITLE
symLinks:Enhance the compatibility of regen.sh

### DIFF
--- a/src/test/resources/symlinks/regen.sh
+++ b/src/test/resources/symlinks/regen.sh
@@ -13,4 +13,8 @@ echo -ne 'content' > entry2
 zip  --symlinks ../non_existing_symlink.zip entry1 entry2
 cd ..
 rm -rf non_existing_symlink
-LC_ALL=C sed  -i '' 's/entry2/entry1/' non_existing_symlink.zip
+if [ "x$(uname)" = "xLinux" ];then
+    LC_ALL=C sed  -i  's/entry2/entry1/' non_existing_symlink.zip
+else
+    LC_ALL=C sed  -i '' 's/entry2/entry1/' non_existing_symlink.zip
+fi


### PR DESCRIPTION
The regen.sh script throws an error on Linux due to the ( sed -i '' )
command, which is a syntax error on Linux because "-i " cannot be 
followed by '' . To improve the script's compatibility, use the "uname" 
command to detect the operating system type and apply ( sed -i ) 
on Linux accordingly.