### PR TITLE
Utilize VT if possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,5 +213,11 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>plexus-release</id>
+      <properties>
+        <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,26 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>java21</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <release>21</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <!-- olamy: exclude files with strange names as failed here on osx -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,26 +149,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>java21</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <phase>compile</phase>
-            <configuration>
-              <release>21</release>
-              <compileSourceRoots>
-                <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
-              </compileSourceRoots>
-              <multiReleaseOutput>true</multiReleaseOutput>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <!-- olamy: exclude files with strange names as failed here on osx -->
@@ -202,4 +182,36 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>jdk21</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>java21</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <phase>compile</phase>
+                <configuration>
+                  <release>21</release>
+                  <compileSourceRoots>
+                    <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
+                  </compileSourceRoots>
+                  <multiReleaseOutput>true</multiReleaseOutput>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreator.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreator.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.io.UncheckedIOException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 
@@ -119,8 +118,8 @@ public class ConcurrentJarCreator {
         manifest = createDeferred(defaultSupplier);
         directories = createDeferred(defaultSupplier);
         synchronousEntries = createDeferred(defaultSupplier);
-        parallelScatterZipCreator =
-                new ParallelScatterZipCreator(Executors.newFixedThreadPool(nThreads), defaultSupplier);
+        parallelScatterZipCreator = new ParallelScatterZipCreator(
+                ConcurrentJarCreatorExecutorServiceFactory.createExecutorService(nThreads), defaultSupplier);
     }
 
     /**

--- a/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
@@ -24,6 +24,12 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Classic (pre Java 21) implementation. Create one thread eagerly, but allow pool to scale up to provided
+ * number (usually set to Java reported CPU count). Apply same thread names as well.
+ *
+ * @since 4.10.1
+ */
 public class ConcurrentJarCreatorExecutorServiceFactory {
     private static final AtomicInteger POOL_COUNTER = new AtomicInteger();
 

--- a/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.codehaus.plexus.archiver.zip;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConcurrentJarCreatorExecutorServiceFactory {
+    private static final AtomicInteger POOL_COUNTER = new AtomicInteger();
+
+    static ExecutorService createExecutorService(int poolSize) {
+        ThreadGroup threadGroup = Thread.currentThread().getThreadGroup();
+        int poolCount = POOL_COUNTER.incrementAndGet();
+        AtomicInteger threadCounter = new AtomicInteger();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread =
+                        new Thread(threadGroup, r, "plx-arch-" + poolCount + "-" + threadCounter.incrementAndGet());
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+        return new ThreadPoolExecutor(1, poolSize, 1L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), threadFactory);
+    }
+}

--- a/src/main/java21/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
+++ b/src/main/java21/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
@@ -21,6 +21,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Post Java 21 implementation. Create one Virtual Thread per task execution. Apply same thread names as well.
+ *
+ * @since 4.10.1
+ */
 public class ConcurrentJarCreatorExecutorServiceFactory {
     private static final AtomicInteger POOL_COUNTER = new AtomicInteger();
 

--- a/src/main/java21/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
+++ b/src/main/java21/org/codehaus/plexus/archiver/zip/ConcurrentJarCreatorExecutorServiceFactory.java
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.codehaus.plexus.archiver.zip;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ConcurrentJarCreatorExecutorServiceFactory {
+    private static final AtomicInteger POOL_COUNTER = new AtomicInteger();
+
+    static ExecutorService createExecutorService(int poolSize) {
+        int poolCount = POOL_COUNTER.incrementAndGet();
+        AtomicInteger threadCounter = new AtomicInteger();
+        return Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual().name("plx-arch-" + poolCount + "-" + threadCounter.incrementAndGet()).factory());
+    }
+}


### PR DESCRIPTION
Also, lessen the pressure (creating eagerly as many threads as many CPU cores per archive is a huge pressure), as many times they are simply unused.