### PR TITLE
test 1970 timestamp

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipArchiverTest.java
@@ -816,6 +816,12 @@ class ZipArchiverTest extends BasePlexusArchiverTest {
             assertEquals(almostMinDosTime, zf.getEntry("file-with-odd-time.txt").getTime());
             assertEquals(almostMinDosTime, zf.getEntry("foo/").getTime());
         }
+
+        final File zipFile1970 = getTestFile("target/output/zip-with-fixed-entry-modification-times-1970.zip");
+        final ZipArchiver archiver1970 = getZipArchiver(zipFile1970);
+        archiver1970.setLastModifiedTime(FileTime.fromMillis(0));
+        archiver1970.addDirectory(new File("src/test/resources/zip-timestamp"));
+        archiver1970.createArchive();
     }
 
     @Test


### PR DESCRIPTION
diving into https://github.com/apache/maven-archiver/pull/313

trying to reproduce at Plexus Archiver level:

```
$ zipdetails target/output/zip-with-fixed-entry-modification-times-1970.zip

00000 LOCAL HEADER #1       04034B50
00004 Extract Zip Spec      0A '1.0'
00005 Extract OS            00 'MS-DOS'
00006 General Purpose Flag  0800
      [Bit 11]              1 'Language Encoding'
00008 Compression Method    0000 'Stored'
0000A Last Mod Time         00210000 'Tue Jan  1 01:00:00 1980'
0000E CRC                   00000000
00012 Compressed Length     00000000
00016 Uncompressed Length   00000000
0001A Filename Length       0004
0001C Extra Length          002D
0001E Filename              'foo/'
00022 Extra ID #0001        5455 'UT: Extended Timestamp'
00024   Length              0005
00026   Flags               '01 mod'
00027   Mod Time            00000001 'Thu Jan  1 01:00:01 1970'
0002B Extra ID #0002        000A 'NTFS FileTimes'
0002D   Length              0020
0002F   Reserved            00000000
00033   Tag1                0001
00035   Size1               0018
00037   Mtime               019DB1DED66F85F0 'Thu Jan  1 01:00:01
                            1970 999000000ns'
0003F   Atime               0000000000000000 'Mon Jan  1 00:09:21
                            1601 0ns'
00047   Ctime               0000000000000000 'Mon Jan  1 00:09:21
                            1601 0ns'

...
```

notice the 1 hour difference in `5455 'UT: Extended Timestamp'` value