### PR TITLE
Replace `FileUtils.deleteDirectory(File)` with JDK provided API

### DIFF
--- a/src/test/java/org/codehaus/plexus/archiver/DuplicateFilesTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/DuplicateFilesTest.java
@@ -9,9 +9,9 @@ import java.util.Enumeration;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarLongFileMode;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/codehaus/plexus/archiver/rar/RarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/rar/RarArchiverTest.java
@@ -17,10 +17,10 @@ package org.codehaus.plexus.archiver.rar;
 
 import java.io.File;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.BasePlexusArchiverTest;
 import org.codehaus.plexus.archiver.UnArchiver;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarUnArchiverTest.java
@@ -2,11 +2,11 @@ package org.codehaus.plexus.archiver.tar;
 
 import java.io.File;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.TestSupport;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.components.io.fileselectors.FileSelector;
 import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/codehaus/plexus/archiver/war/WarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/war/WarArchiverTest.java
@@ -2,11 +2,11 @@ package org.codehaus.plexus.archiver.war;
 
 import java.io.File;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ResourceIterator;
 import org.codehaus.plexus.archiver.TestSupport;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/codehaus/plexus/archiver/zip/ZipUnArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/zip/ZipUnArchiverTest.java
@@ -7,13 +7,13 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.TestSupport;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.components.io.fileselectors.FileInfo;
 import org.codehaus.plexus.components.io.fileselectors.FileSelector;
 import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
-import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.codehaus.plexus.PlexusFileUtilsRecipes%24DeleteDirectoryFileRecipe?organizationId=NzQ1YmJlODUtZjNkMy00OTNkLThhNDAtZWJmZDg4N2U1ZjU1