### PR TITLE
Fix ZIP CRC regression in OffloadingOutputStream

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/zip/ByteArrayOutputStream.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ByteArrayOutputStream.java
@@ -262,7 +262,7 @@ public class ByteArrayOutputStream extends OutputStream {
         } else {
             // Throw away old buffers
             currentBuffer = null;
-            int size = buffers.get(0).length;
+            int size = buffers.isEmpty() ? 1024 : buffers.get(0).length;
             buffers.clear();
             needNewBuffer(size);
             reuseBuffers = true;

--- a/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreator.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/ConcurrentJarCreator.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.io.UncheckedIOException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
@@ -54,6 +55,8 @@ public class ConcurrentJarCreator {
     private final ScatterZipOutputStream synchronousEntries;
 
     private final ParallelScatterZipCreator parallelScatterZipCreator;
+
+    private final ExecutorService es;
 
     private long zipCloseElapsed;
 
@@ -118,8 +121,8 @@ public class ConcurrentJarCreator {
         manifest = createDeferred(defaultSupplier);
         directories = createDeferred(defaultSupplier);
         synchronousEntries = createDeferred(defaultSupplier);
-        parallelScatterZipCreator =
-                new ParallelScatterZipCreator(Executors.newFixedThreadPool(nThreads), defaultSupplier);
+        es = Executors.newFixedThreadPool(nThreads);
+        parallelScatterZipCreator = new ParallelScatterZipCreator(es, defaultSupplier);
     }
 
     /**
@@ -161,11 +164,15 @@ public class ConcurrentJarCreator {
 
     public void writeTo(ZipArchiveOutputStream targetStream)
             throws IOException, ExecutionException, InterruptedException {
-        metaInfDir.writeTo(targetStream);
-        manifest.writeTo(targetStream);
-        directories.writeTo(targetStream);
-        synchronousEntries.writeTo(targetStream);
-        parallelScatterZipCreator.writeTo(targetStream);
+        try {
+            metaInfDir.writeTo(targetStream);
+            manifest.writeTo(targetStream);
+            directories.writeTo(targetStream);
+            synchronousEntries.writeTo(targetStream);
+            parallelScatterZipCreator.writeTo(targetStream);
+        } finally {
+            es.shutdown();
+        }
         long startAt = System.currentTimeMillis();
         targetStream.close();
         zipCloseElapsed = System.currentTimeMillis() - startAt;

--- a/src/main/java/org/codehaus/plexus/archiver/zip/DeferredScatterOutputStream.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/DeferredScatterOutputStream.java
@@ -17,9 +17,10 @@
  */
 package org.codehaus.plexus.archiver.zip;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.commons.compress.parallel.ScatterGatherBackingStore;
 
@@ -48,9 +49,9 @@ public class DeferredScatterOutputStream implements ScatterGatherBackingStore {
 
     @Override
     public void close() throws IOException {
-        File file = dfos.getFile();
+        Path file = dfos.getOutputPath();
         if (file != null) {
-            file.delete();
+            Files.deleteIfExists(file);
         }
     }
 }

--- a/src/main/java/org/codehaus/plexus/archiver/zip/OffloadingOutputStream.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/OffloadingOutputStream.java
@@ -113,7 +113,7 @@ class OffloadingOutputStream extends ThresholdingOutputStream {
     @Override
     protected void thresholdReached() throws IOException {
         outputPath = Files.createTempFile(prefix, suffix);
-        currentOutputStream = Streams.fileOutputStream(outputPath);
+        currentOutputStream = Streams.bufferedOutputStream(Files.newOutputStream(outputPath));
     }
 
     public InputStream getInputStream() throws IOException {

--- a/src/main/java/org/codehaus/plexus/archiver/zip/OffloadingOutputStream.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/OffloadingOutputStream.java
@@ -142,6 +142,10 @@ class OffloadingOutputStream extends ThresholdingOutputStream {
         return null;
     }
 
+    public Path getOutputPath() {
+        return outputPath;
+    }
+
     /**
      * Returns either the output file specified in the constructor or
      * the temporary file created or null.


### PR DESCRIPTION
Avoid CachingOutputStream for temporary scatter fragments as it adds unnecessary complexity and potential for data corruption under high load on Linux. Switching to a plain BufferedOutputStream. Fixes #423

**Root Cause Analysis**
  The investigation revealed that OffloadingOutputStream, which was introduced to reduce heap usage by offloading large ZIP entry fragments to disk, was using Streams.fileOutputStream
  to create its temporary backing files. Recently, Streams.fileOutputStream was updated to always use CachingOutputStream (from plexus-utils).

  CachingOutputStream is designed for final output files; it writes to a separate temporary file and only renames it to the target path upon closing if the content has changed. Using
  it for internal, temporary scatter fragments in a multi-threaded archiving process introduced unnecessary complexity—specifically, redundant temporary files and renames. This
  double-layering was the likely source of transient data corruption and visibility issues on Linux, leading to the reported CRC mismatches.

  **Fix**
  I modified OffloadingOutputStream to use Files.newOutputStream directly, wrapped in a BufferedOutputStream for performance. This bypasses CachingOutputStream for these temporary
  fragments, ensuring a more direct and reliable write path to disk.