### PR TITLE
Rewrite README with usage, status and version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,54 @@
-Plexus-archiver
-===============
+# Plexus Archiver
 
-[![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/codehaus-plexus/plexus-archiver.svg?label=License)](http://www.apache.org/licenses/)
-[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-archiver.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.plexus/plexus-archiver)
+[![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.plexus/plexus-archiver.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.codehaus.plexus/plexus-archiver)
 [![GitHub CI](https://github.com/codehaus-plexus/plexus-archiver/actions/workflows/maven.yml/badge.svg)](https://github.com/codehaus-plexus/plexus-archiver/actions/workflows/maven.yml)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/codehaus/plexus/plexus-archiver/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/codehaus/plexus/plexus-archiver/README.md)
+[![License](https://img.shields.io/github/license/codehaus-plexus/plexus-archiver.svg?label=License)](https://www.apache.org/licenses/LICENSE-2.0)
 
-The current master is now at https://github.com/codehaus-plexus/plexus-archiver
+One API for creating and extracting archives — zip, jar, tar and their compressed variants — regardless of format. It is what `maven-assembly-plugin`, `maven-jar-plugin` and friends use underneath.
 
-## Important Hint
+Built on [Apache Commons Compress](https://commons.apache.org/proper/commons-compress/), adding the things a build tool needs on top of it: include/exclude scanning, file mappers and selectors, permission handling, reproducible output, duplicate strategies, modular JARs and archive size limits.
 
-Based on a hint of snyk.io security team they have found a possible security issue.
-Furthermore they have offered an patch to prevent the possible security issue.
-This patch has been integrated into the Release 3.6.0
+## Status
 
-## Release Notes
+Actively maintained. This is one of the most widely used artifacts in the Maven ecosystem, so public API is kept compatible and changes are deliberately conservative.
 
-Current release notes are maintained on GitHub [releases](https://github.com/codehaus-plexus/plexus-archiver/releases)
+## Using it
 
-You can find details about the historical releases in the [Release Notes](https://github.com/codehaus-plexus/plexus-archiver/blob/master/ReleaseNotes.md).
+```xml
+<dependency>
+  <groupId>org.codehaus.plexus</groupId>
+  <artifactId>plexus-archiver</artifactId>
+  <version>4.12.0</version>
+</dependency>
+```
 
+Check the badge above for the current version.
+
+```java
+@Inject
+@Named("zip")
+Archiver archiver;
+
+archiver.addDirectory(new File("src/main/resources"));
+archiver.setDestFile(new File("target/out.zip"));
+archiver.createArchive();
+```
+
+Components are JSR-330 beans, resolved by role hint (`zip`, `jar`, `tar.gz`, …). No Plexus container is involved — [Eclipse Sisu](https://www.eclipse.org/sisu/) replaced that years ago. The [site](https://codehaus-plexus.github.io/plexus-archiver/) lists every supported format and its hint.
+
+## Requirements
+
+Java 8 or later.
+
+## Documentation
+
+- [Project site](https://codehaus-plexus.github.io/plexus-archiver/) — supported formats, file mappers and selectors
+- [Javadoc](https://javadoc.io/doc/org.codehaus.plexus/plexus-archiver)
+- Release notes for current versions are on [GitHub releases](https://github.com/codehaus-plexus/plexus-archiver/releases); older ones are in [ReleaseNotes.md](ReleaseNotes.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/codehaus-plexus/.github/blob/master/CONTRIBUTING.md). In short: `mvn verify` builds, and run `mvn spotless:apply` before pushing or CI will fail on formatting.
+
+Please report security vulnerabilities privately — see [SECURITY.md](https://github.com/codehaus-plexus/.github/blob/master/SECURITY.md), not a public issue.

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
   <artifactId>plexus-archiver</artifactId>
   <version>4.12.1-SNAPSHOT</version>
   <name>Plexus Archiver Component</name>
+  <description>One API for creating and extracting archives - zip, jar, tar and their compressed
+    variants - regardless of format.</description>
 
   <url>https://codehaus-plexus.github.io/plexus-archiver/</url>
 


### PR DESCRIPTION
Part of codehaus-plexus/.github#58 — **pilot for a README skeleton** I'd like to apply across the org. Reviewing this one shapes the other 16, so please push back on the shape as much as the content.

### The problem

None of our 17 READMEs tells you how to depend on the artifact. Exactly one states a Java baseline. This repo's README, in full, was: four badges, a line saying "The current master is now at https://github.com/codehaus-plexus/plexus-archiver" — shown to a reader who is already on that page — a note about a Snyk-supplied patch that shipped in **3.6.0**, and a link to release notes.

Nothing about what the library does. For an artifact most of the Maven plugin ecosystem depends on, that's the whole job undone.

### The skeleton

| Section | Why |
|---|---|
| One-line what-it-is | Most readers arrive from a transitive dependency and don't know why it's on their classpath |
| **Status** | Whether something is maintained, quiet, or superseded is often the most useful sentence we can write, and we write it nowhere |
| Coordinates | The actual question people arrive with |
| Requirements | Java baseline. Ours vary — mostly 8, but 17 for sec-dispatcher and plexus-xml 4.x — and it's documented in one README out of seventeen |
| Documentation | Site, Javadoc, release notes |
| Contributing | Links the new org-wide guide, and mentions `mvn spotless:apply` — the thing that silently fails a first-timer's CI run |

Deliberately a **floor, not a ceiling**. Repo-specific content stays and gets added to. plexus-classworlds' README + `COMPATIBILITY.md` is what I'm aiming at, not something to flatten.

### Specific to this repo

- Added the relationship to Commons Compress, and what we add on top. This was on the site but not here.
- Added a short JSR-330 usage example, with a note that no Plexus container is involved — that confuses people who know the name.
- Dropped the 3.6.0 Snyk note. It refers to a release from 2018, two major versions ago. `ReleaseNotes.md` stays linked for history.
- Dropped the "current master is now at" line — 2015 migration residue, present in 9 of our READMEs.
- Central links moved from `search.maven.org` to `central.sonatype.com`; licence badge to the `https://` Apache URL.

### Verified, not assumed

The example compiles against the real API — `addDirectory(File)`, `setDestFile(File)`, `createArchive()` in `Archiver.java`, and `@Named("zip")` on `ZipArchiver`. javadoc.io returns 200.

### Two things I'd like a decision on

1. **The hardcoded `4.12.0` in the snippet.** It goes stale on every release. The alternative is omitting the version and pointing at the badge, which is accurate but not copy-pasteable. I've gone with the version plus a note to check the badge — happy to flip if you'd rather not maintain it.
2. **"Actively maintained"** as the status wording. If a repo is genuinely in maintenance-only mode I'd rather say that plainly than have people guess from commit dates. Tell me if that reads wrong for this one.