### PR TITLE
Restore the document metadata dropped when the page was ported

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Plexus Archiver
+author:
+  - Hervé Boutemy
+date: 2018-05-08
+---
+
 # Plexus Archiver
 
 Collection of Plexus components to create archives or extract archives to a directory with a unified [`Archiver`](./apidocs/index.html?org/codehaus/plexus/archiver/Archiver.html)/[`UnArchiver`](./apidocs/index.html?org/codehaus/plexus/archiver/UnArchiver.html) API whatever the archive format is.


### PR DESCRIPTION
Unblocked by the release of plexus parent 26.

The APT source carried a title, an author and a date. Converting the page to Markdown
dropped them, so the generated page lost its `<title>` and its author meta. This puts
them back as YAML front matter, read from the deleted `src/site/apt/index.apt`:
author Hervé Boutemy, dated 2018-05-08.

It could not be done before now: parent 25 runs Spotless over `**/*.md`, and flexmark
rewrites the fence closing a front matter block, silently costing the page the very
metadata being restored. Parent 26 excludes `**/src/site/markdown/**`, so the first
commit here is the parent upgrade.

Verified after the bump — front matter survives the build and the page carries both:

```
<title>Plexus Archiver – Plexus Archiver Component</title>
<meta name="author" content="Hervé Boutemy" />
```