### PR TITLE
Update parent POM to 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>25</version>
+    <version>26</version>
   </parent>
 
   <artifactId>plexus-archiver</artifactId>


### PR DESCRIPTION
Parent 26 stops Spotless formatting `src/site/markdown`. Its flexmark formatter rewrites
the fence that closes a YAML front matter block, so a Doxia page loses its title, author and
date to a build that reports success.

Split out of #439, which needs this to land first. That PR is now the metadata restore alone.