### PR TITLE
Require Java 17 to use this library

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,10 @@ jobs:
         [ 
           {"jdk": "17.0.2", "os": "windows-latest", distribution: "zulu" }
         ]
+      matrix-exclude: >
+        [
+          {"jdk": "8"}
+        ]
 
 #   deploy:
 #     name: Deploy

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>plexus-archiver</artifactId>
-  <version>4.12.1-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <name>Plexus Archiver Component</name>
   <description>One API for creating and extracting archives - zip, jar, tar and their compressed
     variants - regardless of format.</description>
@@ -47,6 +47,7 @@
   </distributionManagement>
 
   <properties>
+    <javaVersion>17</javaVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
     <sisuMavenPluginVersion>1.1.0</sisuMavenPluginVersion>
     <project.build.outputTimestamp>2026-06-08T20:12:28Z</project.build.outputTimestamp>


### PR DESCRIPTION
Since Java 8 the language has been improved a lot.
Keeping this library on Java 8 means being blocked to use new features.
Projects that for some reason need to stay on Java 8 should lock plexus-archiver to version 4.12.0

