### PR TITLE
Establish an automatic module name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.plexus.archiver</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <!-- olamy: exclude files with strange names as failed here on osx -->


### PR DESCRIPTION
`org.codehaus.plexus.archiver` — the artifact's top-level package. Set through `maven-jar-plugin` `manifestEntries`, as plexus-utils does; same pattern as codehaus-plexus/plexus-xml#92.

Verified: `jar --describe-module` reports `org.codehaus.plexus.archiver@5.0.0-SNAPSHOT automatic`.

*This change was created with AI assistance.*