### PR TITLE
Establish an automatic module name on the 4.x line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,17 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.plexus.archiver</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <!-- olamy: exclude files with strange names as failed here on osx -->


### PR DESCRIPTION
The 4.x half of #450. Same name, `org.codehaus.plexus.archiver`, so a downstream moving between the two lines keeps requiring one module.

This is the first PR against the new `4.x` branch, cut from `a86e3ddb` — the `[maven-release-plugin] prepare for next development iteration` commit that follows the `plexus-archiver-4.12.0` tag, so the branch starts at `4.12.1-SNAPSHOT`. Master has since moved on 21 commits to a genuine 5.0.0 line: Java 17 required, Java 17 syntax, ServiceLoader-based `ArchiverManager`, and removals for the next major. 4.12.0 remains the last release usable below Java 17, which is what the branch is for.

Verified: `mvn clean verify` → 340 tests, 0 failures, and `jar --describe-module` reports `org.codehaus.plexus.archiver@4.12.1-SNAPSHOT automatic`.

*This change was created with AI assistance.*