### PR TITLE
Wire the 4.x branch into Dependabot and Release Drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,24 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "4.x"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "4.x"
     schedule:
       interval: "daily"

--- a/.github/release-drafter-4.x.yml
+++ b/.github/release-drafter-4.x.yml
@@ -1,0 +1,5 @@
+_extends: .github:.github/release-drafter.yml
+tag-template: plexus-archiver-$NEXT_PATCH_VERSION
+version-template: 4.$MINOR.$PATCH
+commitish: 4.x
+filter-by-commitish: true

--- a/.github/release-drafter-master.yml
+++ b/.github/release-drafter-master.yml
@@ -1,0 +1,5 @@
+_extends: .github:.github/release-drafter.yml
+tag-template: plexus-archiver-$NEXT_PATCH_VERSION
+version-template: 5.$MINOR.$PATCH
+commitish: master
+filter-by-commitish: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Release Drafter Master
 on:
   push:
     branches:
@@ -8,5 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7.7.0
+        with:
+          config-name: 'release-drafter-master.yml'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to the new `4.x` branch (#451). Neither tool reaches it today.

**Dependabot** reads its configuration only from the default branch, so the `4.x` entries have to be here rather than on `4.x` itself. The existing two entries carried no `target-branch`, which means they covered `master` alone; they now say so explicitly and are joined by a `4.x` pair.

**Release Drafter** ran with no `config-name`, so both branches would have fought over one draft. Each line now has its own config filtered by commitish — `master` versions as `5.$MINOR.$PATCH`, `4.x` as `4.$MINOR.$PATCH`, both extending the org-wide `.github` defaults. The companion change on the `4.x` branch adds its workflow.

Both configs are kept here as well as on their own branch, matching what plexus-xml does.

*This change was created with AI assistance.*