### PR TITLE
Keep the 4.x release drafter config on the 4.x branch

### DIFF
--- a/.github/release-drafter-4.x.yml
+++ b/.github/release-drafter-4.x.yml
@@ -1,0 +1,5 @@
+_extends: .github:.github/release-drafter.yml
+tag-template: plexus-archiver-$NEXT_PATCH_VERSION
+version-template: 4.$MINOR.$PATCH
+commitish: 4.x
+filter-by-commitish: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,12 +1,15 @@
-name: Release Drafter
+name: Release Drafter 4.x
 on:
   push:
     branches:
-      - master
+      - 4.x
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@v7.7.0
+        with:
+          # Resolved against .github/ on the branch this workflow runs on, not on the default branch.
+          config-name: 'release-drafter-4.x.yml'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Companion to #452. The workflow this branch inherited from the release commit still triggers on pushes to `master`, so on `4.x` it never fires. It now fires on `4.x` and reads `release-drafter-4.x.yml` from this branch, filtered by commitish, so the 4.x and 5.x lines draft separate releases instead of overwriting one another.

Dependabot needs nothing here — it reads only the default branch, which is what #452 covers.

Same shape as codehaus-plexus/plexus-xml#95 on its 3.x line.

*This change was created with AI assistance.*