### PR TITLE
Name the sisu property after what it versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <javaVersion>17</javaVersion>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <sisuMavenPluginVersion>1.1.0</sisuMavenPluginVersion>
+    <version.sisu>1.1.0</version.sisu>
     <project.build.outputTimestamp>2026-06-08T20:12:28Z</project.build.outputTimestamp>
   </properties>
 
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
-      <version>${sisuMavenPluginVersion}</version>
+      <version>${version.sisu}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
`sisuMavenPluginVersion` versions the `org.eclipse.sisu.inject` **test dependency**, not the sisu-maven-plugin. The plugin gets its version from the parent, so the two agreed only by coincidence, and bumping one would read as bumping the other.

Same rename plexus-sec-dispatcher made in #138, where the parent's property of that name was actually being borrowed — there it was a build break waiting for plexus-pom 27, here it is only a misleading name, since the property is declared locally.

Value unchanged at 1.1.0.

Verified: `mvn clean verify` green, working tree clean afterwards.

*This change was created with AI assistance.*