### PR TITLE
[4.x] Name the sisu property after what it versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <slf4jVersion>1.7.36</slf4jVersion>
-    <sisuMavenPluginVersion>1.0.0</sisuMavenPluginVersion>
+    <version.sisu>1.0.0</version.sisu>
     <project.build.outputTimestamp>2026-06-08T20:12:28Z</project.build.outputTimestamp>
   </properties>
 
@@ -122,7 +122,7 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
-      <version>${sisuMavenPluginVersion}</version>
+      <version>${version.sisu}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Backport of #464 to the 4.x line.

`sisuMavenPluginVersion` versions the `org.eclipse.sisu.inject` test dependency, not the sisu-maven-plugin, which takes its version from the parent. Value unchanged at **1.0.0** — this branch pins 1.0.0 where master pins 1.1.0, which is exactly the drift the shared-looking name hid.

Verified: `mvn clean verify` green, working tree clean afterwards.

*This change was created with AI assistance.*