### PR TITLE
[4.x] Update parent to plexus 27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>26</version>
+    <version>27</version>
   </parent>
 
   <artifactId>plexus-archiver</artifactId>


### PR DESCRIPTION
Parent bump on the `4.x` line, matching master. 27 raises the build floor to Maven 3.9.0 and renames managed versions to `version.<artifactId>`; this branch references none of the old names.

*This change was created with AI assistance.*