### PR TITLE
Revert slf4j bump to 2.0.18 on the 4.x line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </distributionManagement>
 
   <properties>
-    <slf4jVersion>2.0.18</slf4jVersion>
+    <slf4jVersion>1.7.36</slf4jVersion>
     <version.sisu>1.0.0</version.sisu>
     <project.build.outputTimestamp>2026-06-08T20:12:28Z</project.build.outputTimestamp>
   </properties>


### PR DESCRIPTION
Reverts #463.

The 4.x line stays compatible with Maven 3.9.x, whose core realm exports slf4j 1.7.36, so a compile-scope constraint on the 2.0.x API is not backed by the runtime consumers get. slf4j 2.x belongs on master.

Verified: `mvn clean verify` → BUILD SUCCESS.

*This change was created with AI assistance.*