### PR TITLE
Stop dependabot proposing slf4j 2.x and guice 6+ on 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
     target-branch: "4.x"
     schedule:
       interval: "daily"
+    ignore:
+      # Maven 3.9.x exports slf4j 1.7.x from its core realm, so the 4.x line
+      # cannot compile against the 2.0.x API. See #463 and #469.
+      - dependency-name: "org.slf4j:*"
+        versions: ["[2.0.0,)"]
+      # Maven still embeds Guice 5.1.0 on javax.inject, and Guice 7 dropped
+      # javax.inject entirely. Testing against 6.x or 7.x exercises a
+      # container no consumer runs. See #460.
+      - dependency-name: "com.google.inject:guice"
+        versions: ["[6.0.0,)"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The 4.x line tracks the Maven 3.9 runtime, so two dependabot proposals can never be accepted there:

- slf4j 1.7.x comes from the core realm, so compiling against the 2.0.x API is unbacked at runtime. Bumped in #463, reverted in #469.
- Maven still embeds Guice 5.1.0 on javax.inject, and Guice 7 dropped javax.inject entirely. Guice 6.x or 7.x would exercise a container no consumer runs. Closed on 4.x in #460, and twice before on master in #276 and #425.

Range syntax follows maven and maven-resolver, which already ignore `org.slf4j:*` at `[2.0.0,)`.

The config only takes effect from the default branch, which is why this PR targets master. The master entry is deliberately unchanged, so #458 stays open for a decision on its own merits.

*This change was created with AI assistance.*