### PR TITLE
Draft the version the labels imply, not always a patch

### DIFF
--- a/.github/release-drafter-4.x.yml
+++ b/.github/release-drafter-4.x.yml
@@ -1,5 +1,10 @@
 _extends: .github:.github/release-drafter.yml
-tag-template: plexus-archiver-$NEXT_PATCH_VERSION
+
+# tag-prefix is what lets the drafter parse the version out of the last tag.
+# Without it the drafter reads what it can from the tag string, and plexus-i18n
+# once drafted 18.0.1 by finding the 18 in its own name.
+tag-prefix: plexus-archiver-
+tag-template: plexus-archiver-$RESOLVED_VERSION
 version-template: 4.$MINOR.$PATCH
 commitish: 4.x
 filter-by-commitish: true

--- a/.github/release-drafter-master.yml
+++ b/.github/release-drafter-master.yml
@@ -1,5 +1,10 @@
 _extends: .github:.github/release-drafter.yml
-tag-template: plexus-archiver-$NEXT_PATCH_VERSION
+
+# tag-prefix is what lets the drafter parse the version out of the last tag.
+# Without it the drafter reads what it can from the tag string, and plexus-i18n
+# once drafted 18.0.1 by finding the 18 in its own name.
+tag-prefix: plexus-archiver-
+tag-template: plexus-archiver-$RESOLVED_VERSION
 version-template: 5.$MINOR.$PATCH
 commitish: master
 filter-by-commitish: true


### PR DESCRIPTION
The drafter numbered every release in this repo as a patch, because `$NEXT_PATCH_VERSION` ignores the
version-resolver. `$RESOLVED_VERSION` reads it, so a PR labelled `enhancement` drafts a minor.

`tag-prefix` is the other half: without it the drafter parses the version out of the tag string as best it
can, which is how plexus-i18n came to draft `18.0.1` — it read the 18 out of its own name.

Depends on codehaus-plexus/.github#77, which makes the shared `name-template` resolve the same way.

*This change was created with AI assistance.*