### PR TITLE
Bump plexus-io to 3.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-io</artifactId>
-      <version>3.6.0</version>
+      <version>3.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
plexus-io 3.7.0 went out today. It carries the symlink-following fix, so this is more than a version refresh for archiver.

This is a re-open: the commit was pushed to the branch behind #471/#472 after they had already been merged, so the pin never actually moved.

*This change was created with AI assistance.*