### PR TITLE
Describe the artifact in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
   <artifactId>plexus-archiver</artifactId>
   <version>4.12.1-SNAPSHOT</version>
   <name>Plexus Archiver Component</name>
+  <description>One API for creating and extracting archives - zip, jar, tar and their compressed
+    variants - regardless of format.</description>
 
   <url>https://codehaus-plexus.github.io/plexus-archiver/</url>
 


### PR DESCRIPTION
Sonatype Central rejected the 4.13.0 bundle: the POM on this branch carries no `description`, and the portal does not accept one by inheritance from the parent. master has had it since 4.12.0 — this is the backport.

Nothing from the rejected attempt reached Central; 4.13.0 gets re-cut on top of this.

*This change was created with AI assistance.*