### PR TITLE
Let a FileSet follow symbolic links

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -331,7 +331,7 @@ public abstract class AbstractArchiver implements Archiver, FinalizerEnabled {
         // The PlexusIoFileResourceCollection contains platform-specific File.separatorChar which
         // is an interesting cause of grief, see PLXCOMP-192
         final PlexusIoFileResourceCollection collection = new PlexusIoFileResourceCollection();
-        collection.setFollowingSymLinks(false);
+        collection.setFollowingSymLinks(fileSet.isFollowingSymLinks());
 
         collection.setIncludes(fileSet.getIncludes());
         collection.setExcludes(fileSet.getExcludes());

--- a/src/main/java/org/codehaus/plexus/archiver/FileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/FileSet.java
@@ -14,4 +14,20 @@ public interface FileSet extends BaseFileSet {
      * Returns the file sets base directory.
      */
     File getDirectory();
+
+    /**
+     * Returns whether symbolic links below the base directory are followed.
+     * <p>
+     * When {@code false} (the default), a symbolic link is added to the archive as a link and the
+     * contents of a linked directory are not scanned. When {@code true}, links are resolved: a
+     * linked directory is added as a directory and its target's contents are included.
+     * <p>
+     * Following links means the scan can descend into a directory that links back to one of its own
+     * ancestors, so only enable it for trees known not to contain such cycles.
+     *
+     * @since 4.14.0
+     */
+    default boolean isFollowingSymLinks() {
+        return false;
+    }
 }

--- a/src/main/java/org/codehaus/plexus/archiver/util/DefaultFileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/util/DefaultFileSet.java
@@ -15,6 +15,8 @@ public class DefaultFileSet extends AbstractFileSet<DefaultFileSet> implements F
 
     private File directory;
 
+    private boolean followingSymLinks;
+
     public DefaultFileSet(File directory) {
         this.directory = directory;
     }
@@ -31,6 +33,28 @@ public class DefaultFileSet extends AbstractFileSet<DefaultFileSet> implements F
     @Nonnull
     public File getDirectory() {
         return directory;
+    }
+
+    /**
+     * Sets whether symbolic links below the base directory are followed. Defaults to false.
+     *
+     * @since 4.14.0
+     */
+    public void setFollowingSymLinks(boolean followingSymLinks) {
+        this.followingSymLinks = followingSymLinks;
+    }
+
+    @Override
+    public boolean isFollowingSymLinks() {
+        return followingSymLinks;
+    }
+
+    /**
+     * @since 4.14.0
+     */
+    public DefaultFileSet followingSymLinks(boolean followingSymLinks) {
+        setFollowingSymLinks(followingSymLinks);
+        return this;
     }
 
     public static DefaultFileSet fileSet(File directory) {

--- a/src/test/java/org/codehaus/plexus/archiver/SymlinkTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/SymlinkTest.java
@@ -7,6 +7,7 @@ import org.codehaus.plexus.archiver.dir.DirectoryArchiver;
 import org.codehaus.plexus.archiver.tar.TarArchiver;
 import org.codehaus.plexus.archiver.tar.TarLongFileMode;
 import org.codehaus.plexus.archiver.tar.TarUnArchiver;
+import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
 import org.junit.jupiter.api.Test;
@@ -105,5 +106,38 @@ class SymlinkTest extends TestSupport {
 
         symbolicLink = new File("target/output/dirarchiver-symlink/aDirWithALink/backOutsideToFileX");
         assertTrue(Files.isSymbolicLink(symbolicLink.toPath()));
+    }
+
+    @Test
+    void fileSetDoesNotFollowSymLinksByDefault() {
+        assertFalse(new DefaultFileSet(getTestFile("src/test/resources/symlinks/src")).isFollowingSymLinks());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void followingSymLinksResolvesLinkedDirectories() throws Exception {
+        DirectoryArchiver archiver = (DirectoryArchiver) lookup(Archiver.class, "dir");
+
+        File dummyContent = getTestFile("src/test/resources/symlinks/src");
+        archiver.addFileSet(new DefaultFileSet(dummyContent).followingSymLinks(true));
+        final File archiveFile = new File("target/output/dirarchiver-followed-symlink");
+        archiveFile.mkdirs();
+        archiver.setDestFile(archiveFile);
+
+        archiver.createArchive();
+
+        // a link to a directory becomes the directory, and its target's contents are included
+        File linkedDir = new File(archiveFile, "symDir");
+        assertFalse(Files.isSymbolicLink(linkedDir.toPath()));
+        assertTrue(linkedDir.isDirectory());
+        assertTrue(new File(linkedDir, "targetFile.txt").isFile());
+
+        // including when the target lies outside the base directory
+        assertTrue(new File(archiveFile, "symLinkToDirOnTheOutside/FileInDirOnTheOutside.txt").isFile());
+
+        // a link to a file becomes the file
+        File linkedFile = new File(archiveFile, "symR");
+        assertFalse(Files.isSymbolicLink(linkedFile.toPath()));
+        assertTrue(linkedFile.isFile());
     }
 }


### PR DESCRIPTION
`AbstractArchiver.addFileSet` hardcoded `collection.setFollowingSymLinks(false)`, and neither `Archiver` nor `FileSet` exposed the flag, so no caller could reach it. `FileSet.isFollowingSymLinks()` now drives it.

The default stays false. Preserving links is pinned behaviour downstream — maven-assembly-plugin has an IT asserting `Files.isSymbolicLink` on its output, and MASSEMBLY-785 ("copy symlink target instead of symlink") was closed as not planned. Only a caller that asks gets the resolved tree, so `addDirectory` and every existing `FileSet` behave exactly as before.

This is the archiver half of #160. The consumer end is [MASSEMBLY-1002](https://github.com/apache/maven-assembly-plugin/issues/1213): today an assembly whose fileSet contains a symlinked directory silently loses that directory's contents in every format — `tar.gz` gets a dangling link entry, `zip` gets a regular file holding the link text.

It depends on plexus-io 3.7.0 (codehaus-plexus/plexus-io#187), already in 4.13.0. Before that release, following also left attributes unresolved, so a followed directory arrived as a `PlexusIoSymlinkResource` *and* its contents were added alongside it.

`@since 4.14.0` on the new methods — the getter is a `default` method and the setter is new, so this is source and binary compatible, but it is API and wants a minor.

Verified: `mvn clean verify` → 342 tests, 0 failures. The new `followingSymLinksResolvesLinkedDirectories` test fails with `expected: <false> but was: <true>` when the one-line wiring is reverted.

*This change was created with AI assistance.*
