### PR TITLE
Let a FileSet follow symbolic links

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/AbstractArchiver.java
@@ -284,7 +284,7 @@ public abstract class AbstractArchiver implements Archiver, FinalizerEnabled {
         // The PlexusIoFileResourceCollection contains platform-specific File.separatorChar which
         // is an interesting cause of grief, see PLXCOMP-192
         final PlexusIoFileResourceCollection collection = new PlexusIoFileResourceCollection();
-        collection.setFollowingSymLinks(false);
+        collection.setFollowingSymLinks(fileSet.isFollowingSymLinks());
 
         collection.setIncludes(fileSet.getIncludes());
         collection.setExcludes(fileSet.getExcludes());

--- a/src/main/java/org/codehaus/plexus/archiver/FileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/FileSet.java
@@ -26,4 +26,20 @@ public interface FileSet extends BaseFileSet {
      * Returns the file sets base directory.
      */
     File getDirectory();
+
+    /**
+     * Returns whether symbolic links below the base directory are followed.
+     * <p>
+     * When {@code false} (the default), a symbolic link is added to the archive as a link and the
+     * contents of a linked directory are not scanned. When {@code true}, links are resolved: a
+     * linked directory is added as a directory and its target's contents are included.
+     * <p>
+     * Following links means the scan can descend into a directory that links back to one of its own
+     * ancestors, so only enable it for trees known not to contain such cycles.
+     *
+     * @since 4.14.0
+     */
+    default boolean isFollowingSymLinks() {
+        return false;
+    }
 }

--- a/src/main/java/org/codehaus/plexus/archiver/FileSetSpec.java
+++ b/src/main/java/org/codehaus/plexus/archiver/FileSetSpec.java
@@ -39,6 +39,7 @@ public final class FileSetSpec {
     private CaseSensitivity caseSensitivity = CaseSensitivity.SENSITIVE;
     private DefaultExcludes defaultExcludes = DefaultExcludes.USE;
     private EmptyDirectoryHandling emptyDirectoryHandling = EmptyDirectoryHandling.INCLUDE;
+    private SymbolicLinkHandling symbolicLinkHandling = SymbolicLinkHandling.PRESERVE;
     private List<FileSelector> fileSelectors;
     private InputStreamTransformer streamTransformer;
     private List<FileMapper> fileMappers;
@@ -81,6 +82,11 @@ public final class FileSetSpec {
         return this;
     }
 
+    public FileSetSpec symbolicLinks(SymbolicLinkHandling symbolicLinkHandling) {
+        this.symbolicLinkHandling = Objects.requireNonNull(symbolicLinkHandling, "symbolicLinkHandling");
+        return this;
+    }
+
     public FileSetSpec selectedBy(List<FileSelector> fileSelectors) {
         this.fileSelectors = List.copyOf(fileSelectors);
         return this;
@@ -104,6 +110,7 @@ public final class FileSetSpec {
         fileSet.setCaseSensitive(isCaseSensitive());
         fileSet.setUsingDefaultExcludes(usesBuiltInDefaultExcludes());
         fileSet.setIncludingEmptyDirectories(includesEmptyDirectories());
+        fileSet.setFollowingSymLinks(followsSymbolicLinks());
         fileSet.setFileSelectors(fileSelectors == null ? null : fileSelectors.toArray(FileSelector[]::new));
         if (streamTransformer != null) {
             fileSet.setStreamTransformer(streamTransformer);
@@ -118,6 +125,10 @@ public final class FileSetSpec {
 
     private boolean usesBuiltInDefaultExcludes() {
         return defaultExcludes instanceof BuiltInDefaultExcludes builtIn && builtIn.use;
+    }
+
+    private boolean followsSymbolicLinks() {
+        return ((FixedSymbolicLinkHandling) symbolicLinkHandling).following;
     }
 
     private boolean includesEmptyDirectories() {

--- a/src/main/java/org/codehaus/plexus/archiver/SymbolicLinkHandling.java
+++ b/src/main/java/org/codehaus/plexus/archiver/SymbolicLinkHandling.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MojoHaus and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.codehaus.plexus.archiver;
+
+/**
+ * Controls whether symbolic links below a file set's base directory are resolved.
+ *
+ * @since 5.0.0
+ */
+public sealed interface SymbolicLinkHandling permits FixedSymbolicLinkHandling {
+
+    /**
+     * Adds a symbolic link as a link. The contents of a linked directory are not scanned.
+     */
+    SymbolicLinkHandling PRESERVE = new FixedSymbolicLinkHandling(false);
+
+    /**
+     * Adds a symbolic link as the file or directory it points at, including a linked directory's contents. The scan can
+     * descend into a directory that links back to one of its own ancestors, so use this only for trees known not to
+     * contain such cycles.
+     */
+    SymbolicLinkHandling FOLLOW = new FixedSymbolicLinkHandling(true);
+}
+
+final class FixedSymbolicLinkHandling implements SymbolicLinkHandling {
+    final boolean following;
+
+    FixedSymbolicLinkHandling(boolean following) {
+        this.following = following;
+    }
+}

--- a/src/main/java/org/codehaus/plexus/archiver/util/DefaultFileSet.java
+++ b/src/main/java/org/codehaus/plexus/archiver/util/DefaultFileSet.java
@@ -15,6 +15,8 @@ public class DefaultFileSet extends AbstractFileSet<DefaultFileSet> implements F
 
     private File directory;
 
+    private boolean followingSymLinks;
+
     public DefaultFileSet(File directory) {
         this.directory = directory;
     }
@@ -31,6 +33,28 @@ public class DefaultFileSet extends AbstractFileSet<DefaultFileSet> implements F
     @Nonnull
     public File getDirectory() {
         return directory;
+    }
+
+    /**
+     * Sets whether symbolic links below the base directory are followed. Defaults to false.
+     *
+     * @since 4.14.0
+     */
+    public void setFollowingSymLinks(boolean followingSymLinks) {
+        this.followingSymLinks = followingSymLinks;
+    }
+
+    @Override
+    public boolean isFollowingSymLinks() {
+        return followingSymLinks;
+    }
+
+    /**
+     * @since 4.14.0
+     */
+    public DefaultFileSet followingSymLinks(boolean followingSymLinks) {
+        setFollowingSymLinks(followingSymLinks);
+        return this;
     }
 
     public static DefaultFileSet fileSet(File directory) {

--- a/src/test/java/org/codehaus/plexus/archiver/SymlinkTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/SymlinkTest.java
@@ -107,4 +107,37 @@ class SymlinkTest extends TestSupport {
         symbolicLink = new File("target/output/dirarchiver-symlink/aDirWithALink/backOutsideToFileX");
         assertTrue(Files.isSymbolicLink(symbolicLink.toPath()));
     }
+
+    @Test
+    void fileSetDoesNotFollowSymLinksByDefault() {
+        assertFalse(new DefaultFileSet(getTestFile("src/test/resources/symlinks/src")).isFollowingSymLinks());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void followingSymLinksResolvesLinkedDirectories() throws Exception {
+        DirectoryArchiver archiver = (DirectoryArchiver) lookup(Archiver.class, "dir");
+
+        File dummyContent = getTestFile("src/test/resources/symlinks/src");
+        archiver.addFileSet(new DefaultFileSet(dummyContent).followingSymLinks(true));
+        final File archiveFile = new File("target/output/dirarchiver-followed-symlink");
+        archiveFile.mkdirs();
+        archiver.setDestFile(archiveFile);
+
+        archiver.createArchive();
+
+        // a link to a directory becomes the directory, and its target's contents are included
+        File linkedDir = new File(archiveFile, "symDir");
+        assertFalse(Files.isSymbolicLink(linkedDir.toPath()));
+        assertTrue(linkedDir.isDirectory());
+        assertTrue(new File(linkedDir, "targetFile.txt").isFile());
+
+        // including when the target lies outside the base directory
+        assertTrue(new File(archiveFile, "symLinkToDirOnTheOutside/FileInDirOnTheOutside.txt").isFile());
+
+        // a link to a file becomes the file
+        File linkedFile = new File(archiveFile, "symR");
+        assertFalse(Files.isSymbolicLink(linkedFile.toPath()));
+        assertTrue(linkedFile.isFile());
+    }
 }

--- a/src/test/java/org/codehaus/plexus/archiver/SymlinkTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/SymlinkTest.java
@@ -140,4 +140,20 @@ class SymlinkTest extends TestSupport {
         assertFalse(Files.isSymbolicLink(linkedFile.toPath()));
         assertTrue(linkedFile.isFile());
     }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void fileSetSpecFollowsSymbolicLinksOnRequest() throws Exception {
+        DirectoryArchiver archiver = (DirectoryArchiver) lookup(Archiver.class, "dir");
+
+        File dummyContent = getTestFile("src/test/resources/symlinks/src");
+        archiver.addFileSet(FileSet.of(dummyContent.toPath()).symbolicLinks(SymbolicLinkHandling.FOLLOW));
+        final File archiveFile = new File("target/output/dirarchiver-spec-followed-symlink");
+        archiveFile.mkdirs();
+        archiver.setDestFile(archiveFile);
+
+        archiver.createArchive();
+
+        assertTrue(new File(archiveFile, "symDir/targetFile.txt").isFile());
+    }
 }


### PR DESCRIPTION
Ports #481 to master, plus the piece that only exists on this line.

The first commit is the cherry-pick: `AbstractArchiver.addFileSet` stops hardcoding `collection.setFollowingSymLinks(false)` and reads `FileSet.isFollowingSymLinks()` instead, which defaults to false. See #481 for why the default has to stay false and for the consumer end ([MASSEMBLY-1002](https://github.com/apache/maven-assembly-plugin/issues/1213)).

The second commit adds the option to `FileSetSpec`, which is the entry point on this line and did not exist on 4.x. `SymbolicLinkHandling` takes the sealed-interface shape of `CaseSensitivity` and `EmptyDirectoryHandling` rather than a boolean, so the call site reads `FileSet.of(dir).symbolicLinks(SymbolicLinkHandling.FOLLOW)`. `PRESERVE` is the default and matches today's behaviour.

Verified: `mvn clean verify` → 503 tests, 0 failures.

Merge order matters — this should land after #481 so the 4.14.0 `@since` on `FileSet.isFollowingSymLinks()` is accurate.

*This change was created with AI assistance.*
