### PR TITLE
Set the 4.x line to 4.14.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>plexus-archiver</artifactId>
-  <version>4.13.1-SNAPSHOT</version>
+  <version>4.14.0-SNAPSHOT</version>
   <name>Plexus Archiver Component</name>
   <description>One API for creating and extracting archives - zip, jar, tar and their compressed
     variants - regardless of format.</description>


### PR DESCRIPTION
The symlink API merged for this line is `@since 4.14.0`, and the release drafter now proposes 4.14.0, but the pom still said 4.13.1-SNAPSHOT — `release:prepare` would have defaulted to 4.13.1 unless the version was passed on the command line.

*This change was created with AI assistance.*