### PR TITLE
Pin Guava on the test classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,15 @@
       <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- Guice 5.1.0 drags in Guava 30.1-jre, which CVE-2023-2976 and
+         CVE-2020-8908 cover. Nothing here uses Guava; the pin only keeps
+         the flagged version off the test classpath. -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>33.7.1-jre</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
Guice 5.1.0 resolves Guava 30.1-jre transitively, which is what the two open Dependabot alerts on master point at (CVE-2023-2976, CVE-2020-8908). No code in this project uses Guava, so the test-scoped pin to 33.7.1-jre is only there to keep the flagged version off the classpath.

Redundant once #458 lands — Guice 7.0.0 brings a patched Guava of its own.

*This change was created with AI assistance.*