### PR TITLE
Pin Guava on the test classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,16 @@
       <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- Guice 5.1.0 drags in Guava 30.1-jre, which CVE-2023-2976 and
+         CVE-2020-8908 cover. Nothing here uses Guava; the pin only keeps
+         the flagged version off the test classpath. 33.7.1-jre is still
+         Java 8 bytecode, so it holds on this line. -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>33.7.1-jre</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
The 4.x counterpart of #484. Guice 5.1.0 resolves Guava 30.1-jre transitively (CVE-2023-2976, CVE-2020-8908); no code in this project uses Guava, so the test-scoped pin only keeps the flagged version off the classpath.

Guava 33.7.1-jre still ships Java 8 bytecode, so it holds on this line.

*This change was created with AI assistance.*