### PR TITLE
Ignore SLF4J >= 2.0 on master in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     target-branch: "master"
     schedule:
       interval: "daily"
+    ignore:
+      # Keep slf4j 1.7.x for Maven 3 compatibility
+      - dependency-name: "org.slf4j:*"
+        versions: ["[2.0.0,)"]
 
   - package-ecosystem: "maven"
     directory: "/"


### PR DESCRIPTION
## Summary

Mirror the `org.slf4j:*` ignore rule from the `4.x` branch onto `master`.

This avoids Dependabot proposing SLF4J 2.x upgrades (such as #491) while preserving compatibility with Maven 3.x runtimes.

Supersedes #491.